### PR TITLE
refactor: obfuscate backend URL via Vercel edge proxy

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -1,0 +1,33 @@
+export const config = { runtime: 'edge' };
+
+export default async function handler(request) {
+  const backendUrl = process.env.TUNIX_BACKEND_BASE_URL;
+
+  if (!backendUrl) {
+    return new Response(JSON.stringify({ error: 'Backend not configured' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const url = new URL(request.url);
+  const backendPath = url.pathname.replace(/^\/api/, '');
+  const targetUrl = `${backendUrl}${backendPath}${url.search}`;
+
+  const init = {
+    method: request.method,
+    headers: { 'Content-Type': 'application/json' },
+  };
+
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    init.body = await request.text();
+  }
+
+  const response = await fetch(targetUrl, init);
+  const body = await response.text();
+
+  return new Response(body, {
+    status: response.status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,4 @@
-// const API_BASE_URL = import.meta.env.VITE_TUNIX_BACKEND_BASE_URL || 'https://tunix-crm-backend.fly.dev';
-const API_BASE_URL = 'https://tunix-crm-backend.fly.dev';
+const API_BASE_URL = '/api';
 
 class ApiError extends Error {
   constructor(public status: number, message: string) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,4 +9,13 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'),
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: process.env.TUNIX_BACKEND_BASE_URL || 'http://localhost:3000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- Replaces the hardcoded backend URL in `src/lib/api.ts` with a relative `/api` path — the real backend URL no longer appears anywhere in the client bundle
- Adds `api/[...path].js`, a Vercel Edge Function that reads `TUNIX_BACKEND_BASE_URL` from server-side environment variables and proxies all requests to the actual backend
- Adds a Vite dev server proxy so local development continues to work without any extra tooling

## Setup required
Add the following environment variable in the **Vercel dashboard → Settings → Environment Variables** (do **not** use the `VITE_` prefix):

```
TUNIX_BACKEND_BASE_URL=https://tunix-crm-backend.fly.dev
```

## Test plan
- [ ] Local dev: `yarn dev` — confirm API calls to `/api/*` proxy correctly to the local backend
- [ ] Verify the backend URL does not appear in the built JS bundle (`yarn build && grep -r "fly.dev" dist/`)
- [ ] Deploy to Vercel preview and confirm API calls succeed end-to-end
- [ ] Check Vercel function logs to confirm the edge function is being invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)