### PR TITLE
fix: add Vercel proxy route for backend API requests

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "routes": [
+    { "src": "/api/(.*)", "dest": "https://tunix-crm-backend.fly.dev/$1" },
     { "handle": "filesystem" },
     { "src": "/(.*)", "dest": "/index.html" }
   ]


### PR DESCRIPTION
## Summary
- Adds a proxy route in `vercel.json` to forward `/api/*` requests to `https://tunix-crm-backend.fly.dev`, stripping the `/api` prefix
- Mirrors the existing Vite dev server proxy config, so local and production behaviour are now consistent
- Fixes the `GET /user/superusers` endpoint failing in the Vercel deployment (requests were resolving to the SPA instead of the backend)

## Test plan
- [ ] Deploy to Vercel preview and verify the Users page loads super users successfully
- [ ] Confirm other routes (create, update, get by ID) still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)