### PR TITLE
feat: implement full CRUD for users and clients

### DIFF
--- a/src/components/Clients/ClientProfile.tsx
+++ b/src/components/Clients/ClientProfile.tsx
@@ -32,6 +32,7 @@ interface ClientData {
 }
 interface ClientProfileProps {
   client: ClientData;
+  onDeactivate?: () => void;
 }
 // Mock exercises from the library
 const exerciseLibrary = [{
@@ -84,10 +85,14 @@ const exerciseLibrary = [{
   image: 'https://images.unsplash.com/photo-1599447292180-45fd84092ef4?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80'
 }];
 const ClientProfile = ({
-  client
+  client,
+  onDeactivate,
 }: ClientProfileProps) => {
- 
+
   const [clientData, setClientData] = useState<ClientData>(client);
+  const [isDeactivating, setIsDeactivating] = useState(false);
+  const [newGoal, setNewGoal] = useState('');
+  const [showGoalInput, setShowGoalInput] = useState(false);
 
 
   useEffect(() => {
@@ -102,6 +107,46 @@ const ClientProfile = ({
     }
     fetchClientData();
   }, [client]);
+
+  const handleDeactivate = async () => {
+    if (!window.confirm(`Are you sure you want to deactivate ${clientData.client_name}?`)) return;
+    try {
+      setIsDeactivating(true);
+      await clientApi.decommissionClient(clientData.id);
+      onDeactivate?.();
+    } catch (err) {
+      console.error('Failed to deactivate client:', err);
+      alert('Failed to deactivate client. Please try again.');
+    } finally {
+      setIsDeactivating(false);
+    }
+  };
+
+  const handleAddGoal = async () => {
+    const goal = newGoal.trim();
+    if (!goal) return;
+    const updatedGoals = [...(clientData.goals || []), goal];
+    try {
+      await clientApi.updateClient(clientData.id, { goals: updatedGoals });
+      setClientData(prev => ({ ...prev, goals: updatedGoals }));
+      setNewGoal('');
+      setShowGoalInput(false);
+    } catch (err) {
+      console.error('Failed to add goal:', err);
+      alert('Failed to add goal. Please try again.');
+    }
+  };
+
+  const handleRemoveGoal = async (index: number) => {
+    const updatedGoals = (clientData.goals || []).filter((_, i) => i !== index);
+    try {
+      await clientApi.updateClient(clientData.id, { goals: updatedGoals });
+      setClientData(prev => ({ ...prev, goals: updatedGoals }));
+    } catch (err) {
+      console.error('Failed to remove goal:', err);
+      alert('Failed to remove goal. Please try again.');
+    }
+  };
 
   const [activeTab, setActiveTab] = useState<'overview' | 'programs' | 'metrics' | 'notes'>('overview');
   const [showProgramDetails, setShowProgramDetails] = useState(false);
@@ -158,10 +203,8 @@ const ClientProfile = ({
               <MailIcon size={16} className="mr-2 text-gray-500" />
               Email
             </a>
-            <button className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-red-600 hover:bg-red-700">
-              {/* <CalendarIcon size={16} className="mr-2" />
-              Schedule Session */}
-              Deactivate Client
+            <button onClick={handleDeactivate} disabled={isDeactivating} className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-red-600 hover:bg-red-700 disabled:opacity-50">
+              {isDeactivating ? 'Deactivating...' : 'Deactivate Client'}
             </button>
           </div>
         </div>
@@ -220,7 +263,7 @@ const ClientProfile = ({
               <div className="bg-white border border-gray-200 rounded-lg p-5">
                 <div className="flex items-center justify-between mb-4">
                   <h3 className="text-lg font-medium">Goals</h3>
-                  <button className="text-gray-400 hover:text-gray-600">
+                  <button onClick={() => setShowGoalInput(v => !v)} className="text-gray-400 hover:text-gray-600">
                     <PlusIcon size={16} />
                   </button>
                 </div>
@@ -234,7 +277,7 @@ const ClientProfile = ({
                           </div>
                           <span className="text-sm">{goal}</span>
                         </div>
-                        <button className="text-gray-400 hover:text-gray-600">
+                        <button onClick={() => handleRemoveGoal(index)} className="text-gray-400 hover:text-red-500">
                           <Trash size={16} />
                         </button>
                       </div>
@@ -242,6 +285,21 @@ const ClientProfile = ({
                   ) : (
                     <div className="text-center py-4">
                       <p className="text-sm text-gray-500">No goals set yet</p>
+                    </div>
+                  )}
+                  {showGoalInput && (
+                    <div className="flex items-center gap-2 mt-2">
+                      <input
+                        type="text"
+                        value={newGoal}
+                        onChange={e => setNewGoal(e.target.value)}
+                        onKeyDown={e => e.key === 'Enter' && handleAddGoal()}
+                        placeholder="Add a goal..."
+                        className="flex-1 border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        autoFocus
+                      />
+                      <button onClick={handleAddGoal} className="text-xs px-2 py-1 bg-amber-600 text-white rounded hover:bg-amber-700">Add</button>
+                      <button onClick={() => { setShowGoalInput(false); setNewGoal(''); }} className="text-xs px-2 py-1 border border-gray-300 rounded hover:bg-gray-50">Cancel</button>
                     </div>
                   )}
                 </div>

--- a/src/lib/clientApi.ts
+++ b/src/lib/clientApi.ts
@@ -7,7 +7,7 @@ export const clientApi = {
         method: 'POST',
         body: JSON.stringify({ query }),
     }),
-    createClient : (newClientData: any) => apiRequest<any>('/client', {
+    createClient : (trainerId: string, newClientData: any) => apiRequest<any>(`/client/trainer/${trainerId}`, {
         method: 'POST',
         body: JSON.stringify(newClientData),
     }),

--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { SearchIcon, PlusIcon, FilterIcon, ChevronRightIcon, ArrowUpRightIcon, ClipboardCheckIcon, CalendarIcon, TagIcon, UserIcon } from 'lucide-react';
+import { SearchIcon, PlusIcon, FilterIcon, ChevronRightIcon, ArrowUpRightIcon, ClipboardCheckIcon, CalendarIcon, TagIcon, UserIcon, XIcon } from 'lucide-react';
 import ClientProfile from '../components/Clients/ClientProfile';
 import { Button } from '@/components/ui/button';
 import { clientApi } from '@/lib/clientApi';
@@ -30,6 +30,39 @@ const Clients = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState<'all' | 'active' | 'inactive'>('all');
   const [selectedClient, setSelectedClient] = useState<number | null>(null);
+  const [showAddClient, setShowAddClient] = useState(false);
+  const [addClientForm, setAddClientForm] = useState({ client_name: '', client_email: '', client_phone: '', goals: '' });
+  const [addClientError, setAddClientError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleAddClientSubmit = async () => {
+    if (!userId) return;
+    if (!addClientForm.client_name.trim() || !addClientForm.client_email.trim()) {
+      setAddClientError('Name and email are required.');
+      return;
+    }
+    try {
+      setIsSubmitting(true);
+      setAddClientError(null);
+      const goalsArray = addClientForm.goals.trim()
+        ? addClientForm.goals.split(',').map(g => g.trim()).filter(Boolean)
+        : [];
+      await clientApi.createClient(userId, {
+        client_name: addClientForm.client_name.trim(),
+        client_email: addClientForm.client_email.trim(),
+        client_phone: addClientForm.client_phone.trim() || undefined,
+        goals: goalsArray,
+      });
+      setAddClientForm({ client_name: '', client_email: '', client_phone: '', goals: '' });
+      setShowAddClient(false);
+      const backendClients = await clientApi.getClientsByTrainerId(userId);
+      setClients(backendClients);
+    } catch (err: any) {
+      setAddClientError(err?.message || 'Failed to create client. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
   const filteredClients = clients.filter(client => {
     const matchesSearch = client.client_name.toLowerCase().includes(searchTerm.toLowerCase());
     const matchesStatus = statusFilter === 'all' || (client.isActive ? statusFilter === 'active' : statusFilter === 'inactive');
@@ -48,7 +81,7 @@ const Clients = () => {
               Back to Clients
             </button>
           </div>
-          {clientData && <ClientProfile client={clientData} />}
+          {clientData && <ClientProfile client={clientData} onDeactivate={() => setSelectedClient(null)} />}
         </div> : <div className="bg-white rounded-lg shadow flex-1 flex flex-col">
           <div className="p-4 border-b border-gray-200 flex flex-wrap items-center justify-between gap-4">
             <div className="relative flex-1 max-w-md">
@@ -67,7 +100,7 @@ const Clients = () => {
                   Inactive
                 </Button>
               </div>
-              <Button className="flex items-center px-3 py-2 bg-tan-600 text-white rounded-md text-sm font-medium hover:bg-tan-700">
+              <Button className="flex items-center px-3 py-2 bg-tan-600 text-white rounded-md text-sm font-medium hover:bg-tan-700" onClick={() => setShowAddClient(true)}>
                 <PlusIcon size={16} className="mr-1" />
                 Add Client
               </Button>
@@ -165,6 +198,45 @@ const Clients = () => {
             </div>
           </div>
         </div>}
+      {showAddClient && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg shadow-lg w-full max-w-md">
+            <div className="p-4 border-b border-gray-200 flex justify-between items-center">
+              <h3 className="text-lg font-medium">Add New Client</h3>
+              <button onClick={() => { setShowAddClient(false); setAddClientError(null); }} className="p-1 rounded hover:bg-gray-100">
+                <XIcon size={20} className="text-gray-500" />
+              </button>
+            </div>
+            <div className="p-4 space-y-4">
+              {addClientError && <p className="text-sm text-red-600">{addClientError}</p>}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Name <span className="text-red-500">*</span></label>
+                <input type="text" value={addClientForm.client_name} onChange={e => setAddClientForm(prev => ({ ...prev, client_name: e.target.value }))} className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder="John Doe" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Email <span className="text-red-500">*</span></label>
+                <input type="email" value={addClientForm.client_email} onChange={e => setAddClientForm(prev => ({ ...prev, client_email: e.target.value }))} className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder="john@example.com" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Phone</label>
+                <input type="text" value={addClientForm.client_phone} onChange={e => setAddClientForm(prev => ({ ...prev, client_phone: e.target.value }))} className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder="+1-555-0100" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Goals <span className="text-gray-400 text-xs">(comma-separated)</span></label>
+                <input type="text" value={addClientForm.goals} onChange={e => setAddClientForm(prev => ({ ...prev, goals: e.target.value }))} className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder="Lose weight, Build strength" />
+              </div>
+            </div>
+            <div className="p-4 border-t border-gray-200 flex justify-end gap-2">
+              <button onClick={() => { setShowAddClient(false); setAddClientError(null); }} className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">
+                Cancel
+              </button>
+              <button onClick={handleAddClientSubmit} disabled={isSubmitting} className="px-4 py-2 bg-tan-600 text-white rounded-md text-sm font-medium hover:bg-tan-700 disabled:opacity-50">
+                {isSubmitting ? 'Adding...' : 'Add Client'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>;
 };
 export default Clients;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -78,16 +78,19 @@ const Settings = () => {
     try {
       setIsLoading(true);
       setError(null);
-      const updatedUser = await userApi.updateUser(userId, userData);
-      setUserData({
-        firstName: updatedUser.firstName || '',
-        lastName: updatedUser.lastName || '',
+      const updatedUser = await userApi.updateUser(userId, {
+        first_name: userData.firstName,
+        last_name: userData.lastName,
+        email: userData.email,
+        phone: userData.phone,
+      });
+      setUserData(prev => ({
+        ...prev,
+        firstName: updatedUser.first_name || '',
+        lastName: updatedUser.last_name || '',
         email: updatedUser.email || '',
         phone: updatedUser.phone || '',
-        title: updatedUser.title || '',
-        bio: updatedUser.bio || ''
-      });
-      // You could add a success toast/notification here
+      }));
       alert('Profile updated successfully!');
     } catch (err) {
       console.error('Error updating profile:', err);
@@ -241,8 +244,8 @@ const Settings = () => {
                 <button type="button" className="bg-white py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50">
                   Cancel
                 </button>
-                <button type="submit" className="ml-3 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-tan-600 hover:bg-tan-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-                  Save
+                <button type="button" onClick={handleProfileSave} disabled={isLoading} className="ml-3 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-tan-600 hover:bg-tan-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50">
+                  {isLoading ? 'Saving...' : 'Save'}
                 </button>
               </div>
             </div>}


### PR DESCRIPTION
## Summary

- **Users (Settings):** Fixed profile save — form fields are now correctly mapped to snake_case (`first_name`, `last_name`) before hitting the API, response fields are mapped back to the form state, and the Save button now has a working `onClick` handler with loading/disabled state
- **Clients (Create):** Fixed `clientApi.createClient` to use the correct `POST /client/trainer/{trainerId}` endpoint; added an "Add Client" modal with name, email, phone, and goals fields that refreshes the list on success
- **Clients (Deactivate):** Wired the "Deactivate Client" button in `ClientProfile` to call `DELETE /client/{id}` and navigate back to the client list via the new `onDeactivate` prop
- **Clients (Goals):** Wired the Goals `+` and trash buttons in `ClientProfile` to call `PATCH /client/{id}` with the updated goals array; inline input supports Enter key to submit

## Test plan

- [ ] Settings → Profile tab → edit name/email/phone → Save → verify API call succeeds and fields reflect the response
- [ ] Clients → Add Client → fill required fields (name, email) → submit → verify new client appears in the list
- [ ] Clients → Add Client → submit with empty name or email → verify validation error appears
- [ ] Clients → open a client profile → Deactivate Client → confirm dialog → verify navigates back to list
- [ ] Clients → open a client profile → Goals `+` → type a goal → Add → verify it appears and persists
- [ ] Clients → open a client profile → Goals trash icon → verify goal is removed and persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)