### PR TITLE
feat: client waiver management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ export function App() {
   return (
     <UserProvider>
       <Router>
-        <Routes>
+<Routes>
           <Route path="/" element={<UserSelection />} />
           <Route element={<ProtectedLayout />}>
             <Route path="/dashboard" element={<Dashboard />} />

--- a/src/components/Clients/ClientProfile.tsx
+++ b/src/components/Clients/ClientProfile.tsx
@@ -4,6 +4,7 @@ import ProgressChart from '../Analytics/ProgressChart';
 import ClientNotes from '../Analytics/ClientNotes';
 import { clientApi } from '@/lib/clientApi';
 import { Link } from 'react-router-dom';
+import ClientWaiver from './ClientWaiver';
 interface Program {
   id: number;
   name: string;
@@ -227,6 +228,7 @@ const ClientProfile = ({
       </div>
       <div className="flex-1 overflow-y-auto p-4 sm:p-6">
         {activeTab === 'overview' && <div className="space-y-6">
+            <ClientWaiver clientId={clientData.id} />
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4 sm:gap-6">
               <div className="bg-white border border-gray-200 rounded-lg p-5">
                 <div className="flex items-center justify-between mb-4">

--- a/src/components/Clients/ClientWaiver.tsx
+++ b/src/components/Clients/ClientWaiver.tsx
@@ -1,0 +1,166 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { FileTextIcon, UploadIcon, Trash2Icon, AlertTriangleIcon, CheckCircleIcon, ExternalLinkIcon } from 'lucide-react';
+import { waiverApi, Waiver } from '@/lib/waiverApi';
+
+interface ClientWaiverProps {
+  clientId: string;
+}
+
+const ClientWaiver = ({ clientId }: ClientWaiverProps) => {
+  const [waivers, setWaivers] = useState<Waiver[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [uploading, setUploading] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const fetchWaivers = async () => {
+      try {
+        const data = await waiverApi.getWaivers(clientId);
+        setWaivers(data);
+      } catch (err) {
+        console.error('Failed to fetch waivers:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchWaivers();
+  }, [clientId]);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      setUploading(true);
+      const uploaded = await waiverApi.uploadWaiver(clientId, file);
+      if (uploaded.fileName === 'waiver') uploaded.fileName = file.name;
+      setWaivers(prev => [...prev, uploaded]);
+    } catch (err) {
+      console.error('Failed to upload waiver:', err);
+      alert('Failed to upload waiver. Please try again.');
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  };
+
+  const handleDelete = async (waiverId: string) => {
+    if (!window.confirm('Are you sure you want to remove this waiver?')) return;
+    try {
+      setDeletingId(waiverId);
+      await waiverApi.deleteWaiver(waiverId);
+      setWaivers(prev => prev.filter(w => w.id !== waiverId));
+    } catch (err) {
+      console.error('Failed to delete waiver:', err);
+      alert('Failed to delete waiver. Please try again.');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleViewWaiver = async (waiverId: string) => {
+    try {
+      const signedUrl = await waiverApi.getSignedUrl(waiverId);
+      const res = await fetch(signedUrl);
+      const blob = await res.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = objectUrl;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      a.click();
+      setTimeout(() => URL.revokeObjectURL(objectUrl), 60_000);
+    } catch (err) {
+      console.error('Failed to get waiver URL:', err);
+      alert('Failed to open waiver. Please try again.');
+    }
+  };
+
+  const formatDate = (dateString: string | null): string => {
+    if (!dateString) return '';
+    const d = new Date(dateString);
+    if (isNaN(d.getTime())) return '';
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  };
+
+  if (loading) return null;
+
+  return (
+    <div className="space-y-3">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="*"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+
+      {waivers.length === 0 ? (
+        <div className="flex items-start gap-3 px-4 py-3 bg-amber-50 border border-amber-200 rounded-lg">
+          <AlertTriangleIcon size={18} className="text-amber-500 mt-0.5 flex-shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-amber-800">No waiver on file</p>
+            <p className="text-xs text-amber-600 mt-0.5">This client has not signed a waiver yet.</p>
+          </div>
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-amber-600 rounded-md hover:bg-amber-700 disabled:opacity-50 flex-shrink-0"
+          >
+            <UploadIcon size={13} />
+            {uploading ? 'Uploading...' : 'Upload Waiver'}
+          </button>
+        </div>
+      ) : (
+        <div className="border border-gray-200 rounded-lg overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 bg-green-50 border-b border-gray-200">
+            <div className="flex items-center gap-2">
+              <CheckCircleIcon size={16} className="text-green-600" />
+              <span className="text-sm font-medium text-green-800">Waiver on file</span>
+            </div>
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              disabled={uploading}
+              className="flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-700 disabled:opacity-50"
+            >
+              <UploadIcon size={13} />
+              {uploading ? 'Uploading...' : 'Upload another'}
+            </button>
+          </div>
+          <ul className="divide-y divide-gray-100">
+            {waivers.map(waiver => (
+              <li key={waiver.id} className="flex items-center gap-3 px-4 py-3">
+                <FileTextIcon size={18} className="text-gray-400 flex-shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-800 truncate">{waiver.fileName}</p>
+                  {formatDate(waiver.createdAt) && (
+                    <p className="text-xs text-gray-400">{formatDate(waiver.createdAt)}</p>
+                  )}
+                </div>
+                <div className="flex items-center gap-1 flex-shrink-0">
+                  <button
+                    onClick={() => handleViewWaiver(waiver.id)}
+                    className="p-1.5 text-gray-400 hover:text-amber-600 rounded"
+                    title="View waiver"
+                  >
+                    <ExternalLinkIcon size={15} />
+                  </button>
+                  <button
+                    onClick={() => handleDelete(waiver.id)}
+                    disabled={deletingId === waiver.id}
+                    className="p-1.5 text-gray-400 hover:text-red-500 rounded disabled:opacity-50"
+                    title="Delete waiver"
+                  >
+                    <Trash2Icon size={15} />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ClientWaiver;

--- a/src/lib/waiverApi.ts
+++ b/src/lib/waiverApi.ts
@@ -1,0 +1,57 @@
+const API_BASE_URL = '/api';
+
+export interface Waiver {
+  id: string;
+  clientId: string;
+  fileName: string;
+  createdAt: string | null;
+}
+
+async function waiverRequest<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, options);
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`${response.status}: ${body || response.statusText}`);
+  }
+  return response.json();
+}
+
+// Normalize a raw backend waiver object to our Waiver interface,
+// handling both camelCase and snake_case field names.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function normalizeWaiver(raw: any): Waiver {
+  return {
+    id: raw.id,
+    clientId: raw.clientId ?? raw.client_id ?? '',
+    fileName: raw.fileName ?? raw.file_name ?? raw.originalName ?? raw.original_name ?? raw.name ?? 'waiver',
+    createdAt: raw.createdAt ?? raw.created_at ?? null,
+  };
+}
+
+export const waiverApi = {
+  getWaivers: async (clientId: string): Promise<Waiver[]> => {
+    const data = await waiverRequest<unknown[]>(`/waiver/client/${clientId}`);
+    return data.map(normalizeWaiver);
+  },
+
+  uploadWaiver: async (clientId: string, file: File): Promise<Waiver> => {
+    const formData = new FormData();
+    formData.append('file', file);
+    const data = await waiverRequest<unknown>(`/waiver/client/${clientId}`, {
+      method: 'POST',
+      body: formData,
+    });
+    return normalizeWaiver(data);
+  },
+
+  getSignedUrl: async (waiverId: string): Promise<string> => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data = await waiverRequest<any>(`/waiver/${waiverId}/url`);
+    return data.url ?? data.signedUrl ?? data.signed_url ?? data;
+  },
+
+  deleteWaiver: async (waiverId: string): Promise<void> => {
+    const response = await fetch(`${API_BASE_URL}/waiver/${waiverId}`, { method: 'DELETE' });
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+  },
+};


### PR DESCRIPTION
## Summary
- Adds `ClientWaiver` component to the client profile overview tab, integrated with the `/waiver` backend API
- Shows an amber warning banner when no waiver is on file with a prompt to upload
- Shows a green confirmation card with file list (name, date, view/delete actions) when a waiver exists
- Waiver files are viewed via a blob URL to mask the underlying storage URL from the browser address bar
- Response field names are normalized (camelCase/snake_case) to handle backend response variations

## Test plan
- [ ] Open a client profile — amber "No waiver on file" banner appears if none exists
- [ ] Upload a waiver file — banner switches to green "Waiver on file" with correct filename displayed
- [ ] Click the view icon — file opens in a new tab as a blob URL (storage URL not exposed)
- [ ] Click delete — waiver is removed and banner reverts to warning state
- [ ] Reload the page — existing waivers persist and load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)