### PR TITLE
feat: persist selected superuser across page reloads

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,9 +11,18 @@ import Settings from './pages/Settings';
 import UserSelection from './pages/UserSelection';
 import { UserProvider, useUser } from './context/UserContext';
 
+function UserSelectionGuard() {
+  const { userId, isInitializing } = useUser();
+  if (isInitializing) return null;
+  if (userId) return <Navigate to="/dashboard" replace />;
+  return <UserSelection />;
+}
+
 function ProtectedLayout() {
-  const { userId } = useUser();
+  const { userId, isInitializing } = useUser();
   const [sidebarOpen, setSidebarOpen] = useState(true);
+
+  if (isInitializing) return null;
 
   if (!userId) {
     return <Navigate to="/" replace />;
@@ -37,7 +46,7 @@ export function App() {
     <UserProvider>
       <Router>
 <Routes>
-          <Route path="/" element={<UserSelection />} />
+          <Route path="/" element={<UserSelectionGuard />} />
           <Route element={<ProtectedLayout />}>
             <Route path="/dashboard" element={<Dashboard />} />
             <Route path="/calendar" element={<Calendar />} />

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -4,6 +4,7 @@ import { UserProfile } from '@/hooks/useSettings';
 interface UserContextValue {
   userId: string | null;
   user: UserProfile | null;
+  isInitializing: boolean;
   setUser: (userId: string, user: UserProfile) => void;
   clearUser: () => void;
 }
@@ -15,6 +16,7 @@ const UserContext = createContext<UserContextValue | null>(null);
 export function UserProvider({ children }: { children: React.ReactNode }) {
   const [userId, setUserId] = useState<string | null>(null);
   const [user, setUserState] = useState<UserProfile | null>(null);
+  const [isInitializing, setIsInitializing] = useState(true);
 
   // Rehydrate from localStorage on mount
   useEffect(() => {
@@ -27,6 +29,8 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       }
     } catch {
       localStorage.removeItem(STORAGE_KEY);
+    } finally {
+      setIsInitializing(false);
     }
   }, []);
 
@@ -43,7 +47,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <UserContext.Provider value={{ userId, user, setUser, clearUser }}>
+    <UserContext.Provider value={{ userId, user, isInitializing, setUser, clearUser }}>
       {children}
     </UserContext.Provider>
   );


### PR DESCRIPTION
## Summary
- Adds `isInitializing` flag to `UserContext` that stays `true` until the localStorage rehydration `useEffect` completes
- `ProtectedLayout` returns `null` while initializing, preventing premature redirect to `/` on reload
- New `UserSelectionGuard` wraps the `/` route — skips the selection screen and redirects to `/dashboard` if a user is already stored

## Test plan
- [ ] Select a superuser and navigate to any dashboard page, then reload — should stay on the same page
- [ ] Open the app fresh (no stored user) — should show the user selection screen
- [ ] After selecting a user, navigating directly to `/` should redirect to `/dashboard`
- [ ] Clearing the user (logout) should redirect back to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)