### PR TITLE
feat: exercise catalog with CRUD operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dist-ssr
 *.sw?
 
 .env
+
+SPEC*.md

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import ProgramBuilder from './pages/ProgramBuilder';
 import ClientAnalytics from './pages/ClientAnalytics';
 import Clients from './pages/Clients';
 import Settings from './pages/Settings';
+import ExercisesPage from './pages/ExercisesPage';
 import UserSelection from './pages/UserSelection';
 import { UserProvider, useUser } from './context/UserContext';
 
@@ -54,6 +55,7 @@ export function App() {
             <Route path="/client-analytics" element={<ClientAnalytics />} />
             <Route path="/clients" element={<Clients />} />
             <Route path="/settings" element={<Settings />} />
+            <Route path="/exercises" element={<ExercisesPage />} />
             <Route path="*" element={<Navigate to="/dashboard" replace />} />
           </Route>
         </Routes>

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { Home, Calendar, Users, ChevronLeft, ChevronRight, LogOut } from 'lucide-react';
+import { Home, Calendar, Users, Dumbbell, ChevronLeft, ChevronRight, LogOut } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useUser } from '@/context/UserContext';
 
@@ -42,6 +42,12 @@ const Sidebar = ({ sidebarOpen, setSidebarOpen }: SidebarProps) => {
       icon: <Users size={20} />,
       path: '/clients',
       notifications: notifications.clients,
+    },
+    {
+      name: 'Exercises',
+      icon: <Dumbbell size={20} />,
+      path: '/exercises',
+      notifications: 0,
     },
     // {
     //   name: 'Program Builder',

--- a/src/components/exercises/ExerciseDeleteDialog.tsx
+++ b/src/components/exercises/ExerciseDeleteDialog.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from "react";
+import { Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { ApiError } from "@/lib/api";
+import type { Exercise } from "@/types/exercise";
+
+interface ExerciseDeleteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  exercise: Exercise | null;
+  onDeleteExercise: (id: string) => Promise<void>;
+  onToast: (message: string, type?: "error" | "success") => void;
+}
+
+export function ExerciseDeleteDialog({
+  open,
+  onOpenChange,
+  exercise,
+  onDeleteExercise,
+  onToast,
+}: ExerciseDeleteDialogProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  async function handleConfirm() {
+    if (!exercise) return;
+    setIsDeleting(true);
+    try {
+      await onDeleteExercise(exercise.id);
+      onOpenChange(false);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 409) {
+          onToast("This exercise is used in a program and cannot be deleted.", "error");
+        } else if (err.status === 404) {
+          onToast("Exercise not found.", "error");
+          onOpenChange(false);
+        } else {
+          onToast("Something went wrong. Please try again.", "error");
+        }
+      } else {
+        onToast("Something went wrong. Please try again.", "error");
+      }
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>Delete Exercise</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete{" "}
+            <strong>{exercise?.name}</strong>? This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isDeleting}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={isDeleting}
+          >
+            {isDeleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/exercises/ExerciseDetail.tsx
+++ b/src/components/exercises/ExerciseDetail.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { ExternalLink } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { Badge } from "@/components/ui/badge";
+import type { Exercise } from "@/types/exercise";
+
+interface ExerciseDetailProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  exercise: Exercise | null;
+}
+
+export function ExerciseDetail({ open, onOpenChange, exercise }: ExerciseDetailProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent>
+        {exercise ? (
+          <>
+            <SheetHeader>
+              <SheetTitle>{exercise.name}</SheetTitle>
+              {exercise.description && (
+                <SheetDescription>{exercise.description}</SheetDescription>
+              )}
+            </SheetHeader>
+
+            <div className="space-y-6">
+              {exercise.tags.length > 0 && (
+                <div>
+                  <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+                    Tags
+                  </p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {exercise.tags.map((tag) => (
+                      <Badge key={tag} variant="secondary">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {exercise.exercise_demo && (
+                <div>
+                  <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+                    Demo
+                  </p>
+                  <a
+                    href={exercise.exercise_demo}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800 hover:underline"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                    Watch Demo
+                  </a>
+                </div>
+              )}
+
+              {!exercise.description && exercise.tags.length === 0 && !exercise.exercise_demo && (
+                <p className="text-sm text-gray-400 italic">No additional details.</p>
+              )}
+            </div>
+          </>
+        ) : (
+          <SheetHeader>
+            <SheetTitle>Exercise Details</SheetTitle>
+            <SheetDescription>No exercise selected.</SheetDescription>
+          </SheetHeader>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/exercises/ExerciseForm.tsx
+++ b/src/components/exercises/ExerciseForm.tsx
@@ -1,0 +1,232 @@
+import React, { useState, useEffect, KeyboardEvent } from "react";
+import { X, Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { ApiError } from "@/lib/api";
+import type { Exercise, CreateExerciseDto, UpdateExerciseDto, ExerciseFormState } from "@/types/exercise";
+
+interface ExerciseFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  defaultValues?: Exercise | null;
+  onCreateExercise: (data: CreateExerciseDto) => Promise<Exercise>;
+  onUpdateExercise: (id: string, data: UpdateExerciseDto) => Promise<Exercise>;
+  onToast: (message: string, type?: "error" | "success") => void;
+}
+
+const emptyForm: ExerciseFormState = {
+  name: "",
+  description: "",
+  tags: [],
+  exercise_demo: "",
+};
+
+function toFormState(exercise: Exercise): ExerciseFormState {
+  return {
+    name: exercise.name,
+    description: exercise.description ?? "",
+    tags: exercise.tags,
+    exercise_demo: exercise.exercise_demo ?? "",
+  };
+}
+
+export function ExerciseForm({
+  open,
+  onOpenChange,
+  defaultValues,
+  onCreateExercise,
+  onUpdateExercise,
+  onToast,
+}: ExerciseFormProps) {
+  const [form, setForm] = useState<ExerciseFormState>(emptyForm);
+  const [tagInput, setTagInput] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<{ name?: string; general?: string }>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isEdit = !!defaultValues;
+
+  useEffect(() => {
+    if (open) {
+      setForm(defaultValues ? toFormState(defaultValues) : emptyForm);
+      setTagInput("");
+      setFieldErrors({});
+    }
+  }, [open, defaultValues]);
+
+  function validate(): boolean {
+    const errors: { name?: string; general?: string } = {};
+    if (!form.name.trim()) {
+      errors.name = "Name is required.";
+    } else if (form.name.trim().length > 255) {
+      errors.name = "Name must be 255 characters or fewer.";
+    }
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  }
+
+  function addTag() {
+    const tag = tagInput.trim();
+    if (tag && !form.tags.includes(tag)) {
+      setForm((prev) => ({ ...prev, tags: [...prev.tags, tag] }));
+    }
+    setTagInput("");
+  }
+
+  function removeTag(tag: string) {
+    setForm((prev) => ({ ...prev, tags: prev.tags.filter((t) => t !== tag) }));
+  }
+
+  function handleTagKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      addTag();
+    } else if (e.key === "Backspace" && tagInput === "" && form.tags.length > 0) {
+      removeTag(form.tags[form.tags.length - 1]);
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!validate()) return;
+
+    setIsSubmitting(true);
+    try {
+      const payload = {
+        name: form.name.trim(),
+        description: form.description.trim() || undefined,
+        tags: form.tags,
+        exercise_demo: form.exercise_demo.trim() || null,
+      };
+
+      if (isEdit && defaultValues) {
+        await onUpdateExercise(defaultValues.id, payload);
+      } else {
+        await onCreateExercise(payload);
+      }
+      onOpenChange(false);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 400) {
+          setFieldErrors({ name: "Invalid input. Please check your entries." });
+        } else if (err.status === 409) {
+          onToast("An exercise with this name already exists.", "error");
+        } else if (err.status === 403) {
+          setFieldErrors({ general: "You don't have permission to perform this action." });
+        } else {
+          onToast("Something went wrong. Please try again.", "error");
+        }
+      } else {
+        onToast("Something went wrong. Please try again.", "error");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "Edit Exercise" : "New Exercise"}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4 mt-2">
+          {fieldErrors.general && (
+            <p className="text-sm text-red-600">{fieldErrors.general}</p>
+          )}
+
+          <div className="space-y-1">
+            <Label htmlFor="exercise-name">
+              Name <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              id="exercise-name"
+              value={form.name}
+              onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
+              placeholder="e.g. Romanian Deadlift"
+              disabled={isSubmitting}
+            />
+            {fieldErrors.name && (
+              <p className="text-xs text-red-600">{fieldErrors.name}</p>
+            )}
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="exercise-description">Description</Label>
+            <Textarea
+              id="exercise-description"
+              value={form.description}
+              onChange={(e) => setForm((p) => ({ ...p, description: e.target.value }))}
+              placeholder="Optional description..."
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="exercise-tags">Tags</Label>
+            <div className="flex flex-wrap gap-1 min-h-[38px] w-full rounded-md border border-gray-300 bg-white px-2 py-1 focus-within:ring-2 focus-within:ring-gray-400 focus-within:ring-offset-2">
+              {form.tags.map((tag) => (
+                <Badge key={tag} variant="secondary" className="gap-1">
+                  {tag}
+                  <button
+                    type="button"
+                    onClick={() => removeTag(tag)}
+                    className="rounded-full hover:bg-gray-300 p-0.5"
+                    disabled={isSubmitting}
+                  >
+                    <X className="h-2.5 w-2.5" />
+                  </button>
+                </Badge>
+              ))}
+              <input
+                id="exercise-tags"
+                value={tagInput}
+                onChange={(e) => setTagInput(e.target.value)}
+                onKeyDown={handleTagKeyDown}
+                onBlur={addTag}
+                placeholder={form.tags.length === 0 ? "Add tags (press Enter)..." : ""}
+                className="flex-1 min-w-[120px] bg-transparent text-sm outline-none placeholder:text-gray-400"
+                disabled={isSubmitting}
+              />
+            </div>
+            <p className="text-xs text-gray-400">Press Enter or comma to add a tag.</p>
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="exercise-demo">Demo URL</Label>
+            <Input
+              id="exercise-demo"
+              value={form.exercise_demo}
+              onChange={(e) => setForm((p) => ({ ...p, exercise_demo: e.target.value }))}
+              placeholder="https://..."
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {isEdit ? "Save Changes" : "Create Exercise"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/exercises/ExerciseList.tsx
+++ b/src/components/exercises/ExerciseList.tsx
@@ -1,0 +1,154 @@
+import React from "react";
+import { ExternalLink, Pencil, Trash2, Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
+import type { Exercise } from "@/types/exercise";
+
+interface ExerciseListProps {
+  exercises: Exercise[];
+  isLoading: boolean;
+  error: string | null;
+  search: string;
+  onSearchChange: (value: string) => void;
+  onEdit: (exercise: Exercise) => void;
+  onDelete: (exercise: Exercise) => void;
+  onView: (exercise: Exercise) => void;
+  onNewExercise: () => void;
+}
+
+export function ExerciseList({
+  exercises,
+  isLoading,
+  error,
+  search,
+  onSearchChange,
+  onEdit,
+  onDelete,
+  onView,
+  onNewExercise,
+}: ExerciseListProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-4">
+        <div className="relative flex-1 max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Input
+            placeholder="Search exercises..."
+            value={search}
+            onChange={(e) => onSearchChange(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <Button onClick={onNewExercise}>New Exercise</Button>
+      </div>
+
+      {error && (
+        <div className="rounded-md bg-red-50 border border-red-200 p-4 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Tags</TableHead>
+              <TableHead>Demo</TableHead>
+              <TableHead className="w-24">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              Array.from({ length: 5 }).map((_, i) => (
+                <TableRow key={i}>
+                  <TableCell><Skeleton className="h-4 w-40" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-32" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-6" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-16" /></TableCell>
+                </TableRow>
+              ))
+            ) : exercises.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="text-center py-12 text-gray-500">
+                  {search
+                    ? `No exercises match "${search}"`
+                    : "No exercises yet. Create your first one!"}
+                </TableCell>
+              </TableRow>
+            ) : (
+              exercises.map((exercise) => (
+                <TableRow
+                  key={exercise.id}
+                  className="cursor-pointer"
+                  onClick={() => onView(exercise)}
+                >
+                  <TableCell className="font-medium">{exercise.name}</TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1">
+                      {exercise.tags.map((tag) => (
+                        <Badge key={tag} variant="secondary">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    {exercise.exercise_demo ? (
+                      <a
+                        href={exercise.exercise_demo}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        className="text-blue-600 hover:text-blue-800"
+                        aria-label="Open demo link"
+                      >
+                        <ExternalLink className="h-4 w-4" />
+                      </a>
+                    ) : (
+                      <span className="text-gray-300">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <div
+                      className="flex items-center gap-1"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onEdit(exercise)}
+                        aria-label="Edit exercise"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onDelete(exercise)}
+                        aria-label="Delete exercise"
+                        className="text-red-500 hover:text-red-700 hover:bg-red-50"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-gray-900 text-white",
+        secondary: "border-transparent bg-gray-100 text-gray-900",
+        outline: "text-gray-700 border-gray-300",
+        destructive: "border-transparent bg-red-100 text-red-800",
+      },
+    },
+    defaultVariants: {
+      variant: "secondary",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <span className={cn(badgeVariants({ variant }), className)} {...props} />
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,90 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+const Sheet = DialogPrimitive.Root
+const SheetTrigger = DialogPrimitive.Trigger
+const SheetClose = DialogPrimitive.Close
+const SheetPortal = DialogPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+SheetOverlay.displayName = "SheetOverlay"
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed right-0 top-0 z-50 h-full w-full max-w-md bg-white shadow-xl duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right flex flex-col",
+        className
+      )}
+      {...props}
+    >
+      <div className="flex-1 overflow-y-auto p-6">{children}</div>
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-gray-400">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = "SheetContent"
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 mb-6", className)} {...props} />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = "SheetTitle"
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-gray-500", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = "SheetDescription"
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,80 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-gray-50 data-[state=selected]:bg-gray-100",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-left align-middle font-medium text-gray-500",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("p-4 align-middle", className)}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/src/hooks/useExercises.ts
+++ b/src/hooks/useExercises.ts
@@ -1,0 +1,114 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useUser } from "@/context/UserContext";
+import { ApiError } from "@/lib/api";
+import * as exercisesApi from "@/lib/exercises-api";
+import type { Exercise, CreateExerciseDto, UpdateExerciseDto } from "@/types/exercise";
+
+export type ToastMessage = {
+  id: number;
+  message: string;
+  type: "error" | "success";
+};
+
+interface UseExercisesReturn {
+  exercises: Exercise[];
+  isLoading: boolean;
+  error: string | null;
+  search: string;
+  setSearch: (search: string) => void;
+  createExercise: (data: CreateExerciseDto) => Promise<Exercise>;
+  updateExercise: (id: string, data: UpdateExerciseDto) => Promise<Exercise>;
+  deleteExercise: (id: string) => Promise<void>;
+  toasts: ToastMessage[];
+  addToast: (message: string, type?: "error" | "success") => void;
+  dismissToast: (id: number) => void;
+}
+
+export function useExercises(): UseExercisesReturn {
+  const { userId } = useUser();
+  const [exercises, setExercises] = useState<Exercise[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+  const toastIdRef = useRef(0);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const addToast = useCallback((message: string, type: "error" | "success" = "error") => {
+    const id = ++toastIdRef.current;
+    setToasts((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 5000);
+  }, []);
+
+  const dismissToast = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const fetchExercises = useCallback(async () => {
+    if (!userId) return;
+    try {
+      setIsLoading(true);
+      setError(null);
+      const data = await exercisesApi.getExercises(userId, debouncedSearch || undefined);
+      setExercises(data);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        window.location.href = "/";
+        return;
+      }
+      setError("Failed to load exercises.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId, debouncedSearch]);
+
+  useEffect(() => {
+    fetchExercises();
+  }, [fetchExercises]);
+
+  const createExercise = useCallback(
+    async (data: CreateExerciseDto): Promise<Exercise> => {
+      if (!userId) throw new Error("No user");
+      const result = await exercisesApi.createExercise(userId, data);
+      await fetchExercises();
+      return result;
+    },
+    [userId, fetchExercises]
+  );
+
+  const updateExercise = useCallback(
+    async (id: string, data: UpdateExerciseDto): Promise<Exercise> => {
+      const result = await exercisesApi.updateExercise(id, data);
+      await fetchExercises();
+      return result;
+    },
+    [fetchExercises]
+  );
+
+  const deleteExercise = useCallback(
+    async (id: string): Promise<void> => {
+      await exercisesApi.deleteExercise(id);
+      await fetchExercises();
+    },
+    [fetchExercises]
+  );
+
+  return {
+    exercises,
+    isLoading,
+    error,
+    search,
+    setSearch,
+    createExercise,
+    updateExercise,
+    deleteExercise,
+    toasts,
+    addToast,
+    dismissToast,
+  };
+}

--- a/src/lib/exercises-api.ts
+++ b/src/lib/exercises-api.ts
@@ -1,0 +1,29 @@
+import { apiRequest } from "./api";
+import type { Exercise, CreateExerciseDto, UpdateExerciseDto } from "@/types/exercise";
+
+export async function getExercises(trainerId: string, search?: string): Promise<Exercise[]> {
+  const params = search ? `?search=${encodeURIComponent(search)}` : "";
+  return apiRequest<Exercise[]>(`/exercise/trainer/${trainerId}${params}`);
+}
+
+export async function getExerciseById(id: string): Promise<Exercise> {
+  return apiRequest<Exercise>(`/exercise/${id}`);
+}
+
+export async function createExercise(trainerId: string, data: CreateExerciseDto): Promise<Exercise> {
+  return apiRequest<Exercise>(`/exercise/trainer/${trainerId}`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateExercise(id: string, data: UpdateExerciseDto): Promise<Exercise> {
+  return apiRequest<Exercise>(`/exercise/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteExercise(id: string): Promise<void> {
+  return apiRequest<void>(`/exercise/${id}`, { method: "DELETE" });
+}

--- a/src/pages/ExercisesPage.tsx
+++ b/src/pages/ExercisesPage.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from "react";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useExercises } from "@/hooks/useExercises";
+import { ExerciseList } from "@/components/exercises/ExerciseList";
+import { ExerciseForm } from "@/components/exercises/ExerciseForm";
+import { ExerciseDeleteDialog } from "@/components/exercises/ExerciseDeleteDialog";
+import { ExerciseDetail } from "@/components/exercises/ExerciseDetail";
+import type { Exercise } from "@/types/exercise";
+
+export default function ExercisesPage() {
+  const {
+    exercises,
+    isLoading,
+    error,
+    search,
+    setSearch,
+    createExercise,
+    updateExercise,
+    deleteExercise,
+    toasts,
+    addToast,
+    dismissToast,
+  } = useExercises();
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [selectedExercise, setSelectedExercise] = useState<Exercise | null>(null);
+
+  function handleNewExercise() {
+    setSelectedExercise(null);
+    setFormOpen(true);
+  }
+
+  function handleEdit(exercise: Exercise) {
+    setSelectedExercise(exercise);
+    setFormOpen(true);
+  }
+
+  function handleView(exercise: Exercise) {
+    setSelectedExercise(exercise);
+    setDetailOpen(true);
+  }
+
+  function handleDelete(exercise: Exercise) {
+    setSelectedExercise(exercise);
+    setDeleteOpen(true);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Exercise Catalog</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Build and manage your personal library of exercises.
+        </p>
+      </div>
+
+      <ExerciseList
+        exercises={exercises}
+        isLoading={isLoading}
+        error={error}
+        search={search}
+        onSearchChange={setSearch}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        onView={handleView}
+        onNewExercise={handleNewExercise}
+      />
+
+      <ExerciseForm
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        defaultValues={selectedExercise}
+        onCreateExercise={createExercise}
+        onUpdateExercise={updateExercise}
+        onToast={addToast}
+      />
+
+      <ExerciseDeleteDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        exercise={selectedExercise}
+        onDeleteExercise={deleteExercise}
+        onToast={addToast}
+      />
+
+      <ExerciseDetail
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+        exercise={selectedExercise}
+      />
+
+      {/* Toast notifications */}
+      <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={cn(
+              "pointer-events-auto flex items-start gap-3 rounded-lg border px-4 py-3 shadow-lg text-sm max-w-sm",
+              toast.type === "error"
+                ? "bg-red-50 border-red-200 text-red-800"
+                : "bg-green-50 border-green-200 text-green-800"
+            )}
+          >
+            <span className="flex-1">{toast.message}</span>
+            <button
+              onClick={() => dismissToast(toast.id)}
+              className="flex-shrink-0 opacity-70 hover:opacity-100"
+              aria-label="Dismiss"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/types/exercise.ts
+++ b/src/types/exercise.ts
@@ -1,0 +1,24 @@
+export type Exercise = {
+  id: string;
+  trainer_id: string;
+  name: string;
+  description: string | null;
+  tags: string[];
+  exercise_demo: string | null;
+};
+
+export type CreateExerciseDto = {
+  name: string;
+  description?: string;
+  tags?: string[];
+  exercise_demo?: string | null;
+};
+
+export type UpdateExerciseDto = Partial<CreateExerciseDto>;
+
+export type ExerciseFormState = {
+  name: string;
+  description: string;
+  tags: string[];
+  exercise_demo: string;
+};


### PR DESCRIPTION
## Summary
- Adds a full **Exercise Catalog** page (`/exercises`) with search, create, edit, delete, and detail view
- Introduces new reusable UI primitives: `badge`, `sheet`, `table`, and `textarea`
- Wires the new route into `App.tsx` and adds an **Exercises** entry in the sidebar with a Dumbbell icon

## Test plan
- [ ] Navigate to `/exercises` — list loads correctly
- [ ] Search filters exercises by name
- [ ] Create a new exercise via the form sheet
- [ ] Edit an existing exercise
- [ ] Delete an exercise via the confirmation dialog
- [ ] View exercise detail panel
- [ ] Existing routes (dashboard, sessions, clients) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)