### PR TITLE
feat: wire up coach dashboard with live data

### DIFF
--- a/src/hooks/useDashboard.ts
+++ b/src/hooks/useDashboard.ts
@@ -15,14 +15,11 @@ function toLocalDateString(date: Date): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
 }
 
-function getCurrentWeekDates(): string[] {
+function getNext7Days(): string[] {
   const today = new Date();
-  const day = today.getDay(); // 0=Sun, 1=Mon
-  const monday = new Date(today);
-  monday.setDate(today.getDate() - (day === 0 ? 6 : day - 1));
   return Array.from({ length: 7 }, (_, i) => {
-    const d = new Date(monday);
-    d.setDate(monday.getDate() + i);
+    const d = new Date(today);
+    d.setDate(today.getDate() + i);
     return toLocalDateString(d);
   });
 }
@@ -51,7 +48,7 @@ export function useDashboard() {
     setIsLoading(true);
     setError(null);
     try {
-      const weekDates = getCurrentWeekDates();
+      const weekDates = getNext7Days();
       const todayStr = toLocalDateString(new Date());
       const results = await Promise.all(weekDates.map((date) => getDashboard(date)));
       const todayIndex = weekDates.indexOf(todayStr);


### PR DESCRIPTION
## Summary

Connects the coach dashboard UI to the live backend API, fixes routing issues, and refines the sessions view.

### Changes

**Auth and routing**
- Enable Bearer token in apiRequest -- token is fetched via GET /user/:id/token on user selection and stored in localStorage
- Fix redirect loop between / and /dashboard: on 401, clear both auth_token and the user context before navigating away

**Dashboard data**
- Wire useDashboard hook to GET /dashboard via getDashboard
- Upcoming sessions shows the next 7 rolling days (today through today+6) rather than the current calendar week
- Filter sessions by end_time greater than now so already-completed sessions are excluded
- Stats cards and unscheduled clients list use today's response; session list aggregates all 7 days in parallel

**UI cleanup**
- Remove the date picker from the dashboard header
- Rename Today's Sessions card to Upcoming Sessions

Generated with [Claude Code](https://claude.com/claude-code)