### PR TITLE
feat: add Program Builder with list view and program CRUD

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "magic-patterns-vite-template",
       "version": "0.0.1",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@radix-ui/react-dialog": "1.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.15",
@@ -528,6 +530,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@radix-ui/react-dialog": "1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.15",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import Sidebar from './components/Layout/Sidebar';
 import Header from './components/Layout/Header';
 import Dashboard from './pages/Dashboard';
 import Calendar from './pages/Calendar';
-import ProgramBuilder from './pages/ProgramBuilder';
+import ProgramsPage from './pages/Programs';
 import ClientAnalytics from './pages/ClientAnalytics';
 import Clients from './pages/Clients';
 import Settings from './pages/Settings';
@@ -51,7 +51,7 @@ export function App() {
           <Route element={<ProtectedLayout />}>
             <Route path="/dashboard" element={<Dashboard />} />
             <Route path="/calendar" element={<Calendar />} />
-            <Route path="/program-builder" element={<ProgramBuilder />} />
+            <Route path="/programs" element={<ProgramsPage />} />
             <Route path="/client-analytics" element={<ClientAnalytics />} />
             <Route path="/clients" element={<Clients />} />
             <Route path="/settings" element={<Settings />} />

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { Home, Calendar, Users, Dumbbell, ChevronLeft, ChevronRight, LogOut } from 'lucide-react';
+import { Home, Calendar, Users, Dumbbell, LayoutList, ChevronLeft, ChevronRight, LogOut } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useUser } from '@/context/UserContext';
 
@@ -49,12 +49,12 @@ const Sidebar = ({ sidebarOpen, setSidebarOpen }: SidebarProps) => {
       path: '/exercises',
       notifications: 0,
     },
-    // {
-    //   name: 'Program Builder',
-    //   icon: <Dumbbell size={20} />,
-    //   path: '/program-builder',
-    //   notifications: notifications.programBuilder
-    // },
+    {
+      name: 'Programs',
+      icon: <LayoutList size={20} />,
+      path: '/programs',
+      notifications: 0,
+    },
     // {
     //   name: 'Client Analytics',
     //   icon: <BarChart size={20} />,

--- a/src/components/ProgramBuilder/AddExerciseSheet.tsx
+++ b/src/components/ProgramBuilder/AddExerciseSheet.tsx
@@ -1,0 +1,225 @@
+import React, { useState, useEffect, useRef } from 'react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getExercises } from '@/lib/exercises-api';
+import type { Exercise } from '@/types/exercise';
+import type { AddExerciseDto } from '@/types/program';
+
+type AddExerciseSheetProps = {
+  userId: string;
+  programId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAdd: (data: AddExerciseDto) => Promise<void>;
+};
+
+type InlineForm = {
+  sets: string;
+  reps: string;
+  durationSeconds: string;
+  notes: string;
+};
+
+export function AddExerciseSheet({
+  userId,
+  open,
+  onOpenChange,
+  onAdd,
+}: AddExerciseSheetProps) {
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [exercises, setExercises] = useState<Exercise[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [form, setForm] = useState<InlineForm>({
+    sets: '',
+    reps: '',
+    durationSeconds: '',
+    notes: '',
+  });
+  const [addingId, setAddingId] = useState<string | null>(null);
+  const [successId, setSuccessId] = useState<string | null>(null);
+  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  useEffect(() => {
+    if (!open) return;
+    setIsLoading(true);
+    getExercises(userId, debouncedSearch || undefined)
+      .then((data) => setExercises(data))
+      .catch(() => null)
+      .finally(() => setIsLoading(false));
+  }, [userId, debouncedSearch, open]);
+
+  useEffect(() => {
+    if (!open) {
+      setSearch('');
+      setExpandedId(null);
+      setSuccessId(null);
+    }
+  }, [open]);
+
+  function handleExpand(exerciseId: string) {
+    if (expandedId === exerciseId) {
+      setExpandedId(null);
+    } else {
+      setExpandedId(exerciseId);
+      setForm({ sets: '', reps: '', durationSeconds: '', notes: '' });
+    }
+  }
+
+  async function handleAdd(exercise: Exercise) {
+    setAddingId(exercise.id.toString());
+    try {
+      const dto: AddExerciseDto = {
+        exercise_id: exercise.id,
+        sets: form.sets ? parseInt(form.sets, 10) : undefined,
+        reps: form.reps || undefined,
+        duration_seconds: form.durationSeconds
+          ? parseInt(form.durationSeconds, 10)
+          : undefined,
+        notes: form.notes || undefined,
+      };
+      await onAdd(dto);
+      setExpandedId(null);
+      setSuccessId(exercise.id);
+      if (successTimerRef.current) clearTimeout(successTimerRef.current);
+      successTimerRef.current = setTimeout(() => setSuccessId(null), 2000);
+    } finally {
+      setAddingId(null);
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Add Exercise</SheetTitle>
+        </SheetHeader>
+
+        <div className="mb-4">
+          <Input
+            placeholder="Search exercises..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          {isLoading ? (
+            <>
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </>
+          ) : exercises.length === 0 ? (
+            <p className="text-sm text-gray-500 text-center py-4">No exercises found.</p>
+          ) : (
+            exercises.map((exercise) => {
+              const id = exercise.id;
+              const isExpanded = expandedId === id;
+              const isSuccess = successId === id;
+
+              return (
+                <div
+                  key={id}
+                  className="border border-gray-200 rounded-lg overflow-hidden"
+                >
+                  <div className="flex items-center gap-3 p-3">
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium text-sm text-gray-900">{exercise.name}</p>
+                      <div className="flex flex-wrap gap-1 mt-1">
+                        {exercise.tags.map((tag) => (
+                          <Badge key={tag} variant="secondary" className="text-xs">
+                            {tag}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                    {isSuccess ? (
+                      <span className="text-xs text-green-600 font-medium">Added!</span>
+                    ) : (
+                      <Button
+                        size="sm"
+                        onClick={() => handleExpand(id)}
+                        variant={isExpanded ? 'outline' : 'default'}
+                      >
+                        {isExpanded ? 'Cancel' : 'Add'}
+                      </Button>
+                    )}
+                  </div>
+
+                  {isExpanded && (
+                    <div className="border-t border-gray-100 p-3 space-y-2 bg-gray-50">
+                      <div className="flex gap-2">
+                        <div className="flex-1">
+                          <label className="text-xs text-gray-500">Sets</label>
+                          <Input
+                            type="number"
+                            min="0"
+                            value={form.sets}
+                            onChange={(e) => setForm((f) => ({ ...f, sets: e.target.value }))}
+                            placeholder="e.g. 3"
+                          />
+                        </div>
+                        <div className="flex-1">
+                          <label className="text-xs text-gray-500">Reps</label>
+                          <Input
+                            value={form.reps}
+                            onChange={(e) => setForm((f) => ({ ...f, reps: e.target.value }))}
+                            placeholder="e.g. 8-10"
+                          />
+                        </div>
+                        <div className="flex-1">
+                          <label className="text-xs text-gray-500">Duration (s)</label>
+                          <Input
+                            type="number"
+                            min="0"
+                            value={form.durationSeconds}
+                            onChange={(e) =>
+                              setForm((f) => ({ ...f, durationSeconds: e.target.value }))
+                            }
+                            placeholder="e.g. 30"
+                          />
+                        </div>
+                      </div>
+                      <div>
+                        <label className="text-xs text-gray-500">Notes</label>
+                        <Textarea
+                          value={form.notes}
+                          onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))}
+                          rows={2}
+                          placeholder="Optional notes..."
+                        />
+                      </div>
+                      <Button
+                        className="w-full"
+                        onClick={() => handleAdd(exercise)}
+                        disabled={addingId === id}
+                      >
+                        {addingId === id ? 'Adding...' : 'Confirm Add'}
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/ProgramBuilder/ProgramBuilderHeader.tsx
+++ b/src/components/ProgramBuilder/ProgramBuilderHeader.tsx
@@ -1,0 +1,202 @@
+import React, { useState, useEffect } from 'react';
+import { Edit2, Save, X, FileDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ProgramStatusBadge } from './ProgramStatusBadge';
+import { ProgramTagList } from './ProgramTagList';
+import { TagInput } from './TagInput';
+import type { Program, UpdateProgramDto, ProgramStatus } from '@/types/program';
+
+type ProgramBuilderHeaderProps = {
+  program: Program;
+  isEditMode: boolean;
+  onToggleEditMode: () => void;
+  onUpdate: (data: UpdateProgramDto) => Promise<void>;
+  onExport: () => Promise<void>;
+};
+
+const statusTransitions: Record<ProgramStatus, ProgramStatus[]> = {
+  DRAFT: ['DRAFT', 'READY'],
+  READY: ['READY', 'IN_PROGRESS', 'DRAFT'],
+  IN_PROGRESS: ['IN_PROGRESS', 'COMPLETE', 'DRAFT'],
+  COMPLETE: [],
+};
+
+const statusLabels: Record<ProgramStatus, string> = {
+  DRAFT: 'Draft',
+  READY: 'Ready',
+  IN_PROGRESS: 'In Progress',
+  COMPLETE: 'Complete',
+};
+
+export function ProgramBuilderHeader({
+  program,
+  isEditMode,
+  onToggleEditMode,
+  onUpdate,
+  onExport,
+}: ProgramBuilderHeaderProps) {
+  const [name, setName] = useState(program.name);
+  const [description, setDescription] = useState(program.description ?? '');
+  const [status, setStatus] = useState<ProgramStatus>(program.status);
+  const [tags, setTags] = useState<string[]>(program.tags);
+  const [notes, setNotes] = useState(program.notes ?? '');
+  const [isSaving, setIsSaving] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+
+  useEffect(() => {
+    setName(program.name);
+    setDescription(program.description ?? '');
+    setStatus(program.status);
+    setTags(program.tags);
+    setNotes(program.notes ?? '');
+  }, [program]);
+
+  async function handleSave() {
+    const changed: UpdateProgramDto = {};
+    if (name !== program.name) changed.name = name;
+    if (description !== (program.description ?? '')) changed.description = description;
+    if (status !== program.status) changed.status = status;
+    const tagsChanged =
+      tags.length !== program.tags.length || tags.some((t, i) => t !== program.tags[i]);
+    if (tagsChanged) changed.tags = tags;
+    if (notes !== (program.notes ?? '')) changed.notes = notes;
+
+    if (Object.keys(changed).length === 0) {
+      onToggleEditMode();
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await onUpdate(changed);
+      onToggleEditMode();
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  function handleCancel() {
+    setName(program.name);
+    setDescription(program.description ?? '');
+    setStatus(program.status);
+    setTags(program.tags);
+    setNotes(program.notes ?? '');
+    onToggleEditMode();
+  }
+
+  async function handleExport() {
+    setIsExporting(true);
+    try {
+      await onExport();
+    } finally {
+      setIsExporting(false);
+    }
+  }
+
+  const availableStatuses = statusTransitions[program.status];
+
+  if (isEditMode) {
+    return (
+      <div className="p-6 border-b border-gray-200 space-y-4">
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-gray-500 uppercase tracking-wide">Name</label>
+          <Input value={name} onChange={(e) => setName(e.target.value)} />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+            Description
+          </label>
+          <Textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={2}
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-gray-500 uppercase tracking-wide">Status</label>
+          <Select
+            value={status}
+            onValueChange={(val) => setStatus(val as ProgramStatus)}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {availableStatuses.map((s) => (
+                <SelectItem key={s} value={s}>
+                  {statusLabels[s]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-gray-500 uppercase tracking-wide">Tags</label>
+          <TagInput tags={tags} onChange={setTags} placeholder="e.g. Strength, Mobility..." />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-gray-500 uppercase tracking-wide">Notes</label>
+          <Textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={3} />
+        </div>
+        <div className="flex gap-2">
+          <Button onClick={handleSave} disabled={isSaving} size="sm">
+            <Save className="h-4 w-4 mr-1" />
+            {isSaving ? 'Saving...' : 'Save'}
+          </Button>
+          <Button variant="outline" onClick={handleCancel} disabled={isSaving} size="sm">
+            <X className="h-4 w-4 mr-1" />
+            Cancel
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 border-b border-gray-200">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-3">
+            <h2 className="text-xl font-bold text-gray-900 truncate">{program.name}</h2>
+            <ProgramStatusBadge status={program.status} />
+          </div>
+          <p className="text-sm text-gray-500 mt-1">
+            {program.description ?? <span className="italic">—</span>}
+          </p>
+          {program.tags.length > 0 && (
+            <div className="mt-2">
+              <ProgramTagList tags={program.tags} />
+            </div>
+          )}
+          {program.notes && (
+            <p className="text-sm text-gray-600 mt-2 bg-gray-50 rounded p-2">{program.notes}</p>
+          )}
+          <p className="text-xs text-gray-400 mt-1">Client: {program.client_name}</p>
+        </div>
+        <div className="flex gap-2 flex-shrink-0">
+          {program.status === 'READY' && (
+            <Button variant="outline" size="sm" onClick={handleExport} disabled={isExporting}>
+              <FileDown className="h-4 w-4 mr-1" />
+              {isExporting ? 'Exporting...' : 'Export PDF'}
+            </Button>
+          )}
+          {program.status !== 'COMPLETE' && (
+            <Button variant="outline" size="sm" onClick={onToggleEditMode}>
+              <Edit2 className="h-4 w-4 mr-1" />
+              Edit
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProgramBuilder/ProgramClientFilter.tsx
+++ b/src/components/ProgramBuilder/ProgramClientFilter.tsx
@@ -1,0 +1,58 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { clientApi } from '@/lib/clientApi';
+
+type Client = {
+  id: string;
+  user: { first_name: string; last_name: string };
+};
+
+type ProgramClientFilterProps = {
+  userId: string;
+  selectedClientId: string | undefined;
+  onChange: (clientId: string | undefined) => void;
+};
+
+export function ProgramClientFilter({ userId, selectedClientId, onChange }: ProgramClientFilterProps) {
+  const [clients, setClients] = useState<Client[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setIsLoading(true);
+    clientApi
+      .getClientsByTrainerId(userId)
+      .then((data) => setClients(data as Client[]))
+      .catch(() => null)
+      .finally(() => setIsLoading(false));
+  }, [userId]);
+
+  if (isLoading) {
+    return <Skeleton className="h-9 w-full" />;
+  }
+
+  return (
+    <Select
+      value={selectedClientId ?? 'all'}
+      onValueChange={(val) => onChange(val === 'all' ? undefined : val)}
+    >
+      <SelectTrigger>
+        <SelectValue placeholder="All Clients" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">All Clients</SelectItem>
+        {clients.map((client) => (
+          <SelectItem key={client.id} value={client.id}>
+            {client.user.first_name} {client.user.last_name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/ProgramBuilder/ProgramClientGroup.tsx
+++ b/src/components/ProgramBuilder/ProgramClientGroup.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { ProgramListItem } from './ProgramListItem';
+import type { ProgramSummary } from '@/types/program';
+
+type ProgramClientGroupProps = {
+  clientName: string;
+  programs: ProgramSummary[];
+  activeProgramId: string | null;
+  onSelectProgram: (id: string) => void;
+  onDeleteProgram: (id: string) => Promise<void>;
+};
+
+export function ProgramClientGroup({
+  clientName,
+  programs,
+  activeProgramId,
+  onSelectProgram,
+  onDeleteProgram,
+}: ProgramClientGroupProps) {
+  const hasActive = programs.some((p) => p.id === activeProgramId);
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  // Stay expanded whenever a program in this group is active
+  const expanded = isExpanded || hasActive;
+
+  function handleToggle() {
+    // Don't collapse if an active program lives in this group
+    if (hasActive) return;
+    setIsExpanded((prev) => !prev);
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={handleToggle}
+        className="w-full flex items-center justify-between px-3 py-2 bg-gray-50 hover:bg-gray-100 transition-colors text-left border-b border-gray-200"
+      >
+        <span className="text-xs font-semibold text-gray-600 uppercase tracking-wide truncate">
+          {clientName}{' '}
+          <span className="font-normal normal-case text-gray-400">({programs.length})</span>
+        </span>
+        {hasActive ? null : expanded ? (
+          <ChevronDown className="h-3.5 w-3.5 text-gray-400 flex-shrink-0" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 text-gray-400 flex-shrink-0" />
+        )}
+      </button>
+
+      {expanded && (
+        <div>
+          {programs.map((program) => (
+            <ProgramListItem
+              key={program.id}
+              program={program}
+              isActive={program.id === activeProgramId}
+              onSelect={() => onSelectProgram(program.id)}
+              onDelete={onDeleteProgram}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProgramBuilder/ProgramCreateDialog.tsx
+++ b/src/components/ProgramBuilder/ProgramCreateDialog.tsx
@@ -1,0 +1,176 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { clientApi } from '@/lib/clientApi';
+import { TagInput } from './TagInput';
+import type { CreateProgramDto, Program } from '@/types/program';
+
+type Client = {
+  client_id: string;
+  client_name: string;
+};
+
+type ProgramCreateDialogProps = {
+  userId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreate: (data: CreateProgramDto) => Promise<Program | null>;
+};
+
+export function ProgramCreateDialog({
+  userId,
+  open,
+  onOpenChange,
+  onCreate,
+}: ProgramCreateDialogProps) {
+  const [clients, setClients] = useState<Client[]>([]);
+  const [clientId, setClientId] = useState('');
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+  const [errors, setErrors] = useState<{ clientId?: string; name?: string }>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    clientApi
+      .getClientsByTrainerId(userId)
+      .then((data) => setClients(data as Client[]))
+      .catch(() => null);
+  }, [userId]);
+
+  useEffect(() => {
+    if (!open) {
+      setClientId('');
+      setName('');
+      setDescription('');
+      setTags([]);
+      setErrors({});
+      setSubmitError(null);
+    }
+  }, [open]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const newErrors: { clientId?: string; name?: string } = {};
+    if (!clientId) newErrors.clientId = 'Please select a client.';
+    if (!name.trim()) newErrors.name = 'Program name is required.';
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+    try {
+      const result = await onCreate({
+        client_id: clientId,
+        name: name.trim(),
+        description: description.trim() || undefined,
+        tags,
+      });
+      if (result) {
+        onOpenChange(false);
+      } else {
+        setSubmitError('Failed to create program. Please try again.');
+      }
+    } catch {
+      setSubmitError('Failed to create program. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New Program</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="client">Client</Label>
+            <Select value={clientId} onValueChange={(val) => setClientId(val)}>
+              <SelectTrigger id="client">
+                <SelectValue placeholder="Select a client" />
+              </SelectTrigger>
+              <SelectContent>
+                {clients.map((client) => (
+                  <SelectItem key={client.client_id} value={client.client_id}>
+                    {client.client_name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {errors.clientId && (
+              <p className="text-xs text-red-600">{errors.clientId}</p>
+            )}
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="name">Program Name</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Phase 1 Strength"
+            />
+            {errors.name && (
+              <p className="text-xs text-red-600">{errors.name}</p>
+            )}
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="description">Description (optional)</Label>
+            <Textarea
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Brief description of the program"
+              rows={3}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label>Tags (optional)</Label>
+            <TagInput tags={tags} onChange={setTags} placeholder="e.g. Strength, Mobility..." />
+          </div>
+
+          {submitError && (
+            <p className="text-sm text-red-600">{submitError}</p>
+          )}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Creating...' : 'Create Program'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ProgramBuilder/ProgramExerciseItem.tsx
+++ b/src/components/ProgramBuilder/ProgramExerciseItem.tsx
@@ -1,0 +1,172 @@
+import React, { useState } from 'react';
+import { GripVertical, Trash2, Save, ExternalLink } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import type { ProgramExercise, UpdateProgramExerciseDto } from '@/types/program';
+
+type ProgramExerciseItemProps = {
+  exercise: ProgramExercise;
+  isEditMode: boolean;
+  dragHandleProps?: Record<string, unknown>;
+  onUpdate: (id: string, data: UpdateProgramExerciseDto) => Promise<void>;
+  onRemove: (id: string) => void;
+};
+
+function formatSummary(exercise: ProgramExercise): string {
+  const parts: string[] = [];
+  if (exercise.sets) parts.push(`${exercise.sets} set${exercise.sets !== 1 ? 's' : ''}`);
+  if (exercise.reps) parts.push(`${exercise.reps} reps`);
+  if (exercise.duration_seconds) parts.push(`${exercise.duration_seconds}s`);
+  return parts.join(' × ');
+}
+
+export function ProgramExerciseItem({
+  exercise,
+  isEditMode,
+  dragHandleProps,
+  onUpdate,
+  onRemove,
+}: ProgramExerciseItemProps) {
+  const [sets, setSets] = useState(exercise.sets?.toString() ?? '');
+  const [reps, setReps] = useState(exercise.reps ?? '');
+  const [durationSeconds, setDurationSeconds] = useState(
+    exercise.duration_seconds?.toString() ?? '',
+  );
+  const [notes, setNotes] = useState(exercise.notes ?? '');
+  const [isSaving, setIsSaving] = useState(false);
+
+  async function handleSave() {
+    const changed: UpdateProgramExerciseDto = {};
+    const parsedSets = sets ? parseInt(sets, 10) : undefined;
+    const parsedDuration = durationSeconds ? parseInt(durationSeconds, 10) : undefined;
+
+    if (parsedSets !== (exercise.sets ?? undefined)) changed.sets = parsedSets;
+    if (reps !== (exercise.reps ?? '')) changed.reps = reps || undefined;
+    if (parsedDuration !== (exercise.duration_seconds ?? undefined))
+      changed.duration_seconds = parsedDuration;
+    if (notes !== (exercise.notes ?? '')) changed.notes = notes || undefined;
+
+    setIsSaving(true);
+    try {
+      await onUpdate(exercise.id, changed);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  const summary = formatSummary(exercise);
+
+  return (
+    <div className="flex items-start gap-3 p-4 border border-gray-200 rounded-lg bg-white">
+      {isEditMode && dragHandleProps && (
+        <span
+          {...dragHandleProps}
+          className="flex-shrink-0 mt-1 cursor-grab text-gray-400 hover:text-gray-600"
+          aria-label="Drag to reorder"
+        >
+          <GripVertical className="h-5 w-5" />
+        </span>
+      )}
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-medium text-gray-900">{exercise.exercise_name}</span>
+          {exercise.tags.map((tag) => (
+            <Badge key={tag} variant="secondary" className="text-xs">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+
+        {!isEditMode && (
+          <>
+            {summary && <p className="text-sm text-gray-600 mt-1">{summary}</p>}
+            {exercise.notes && <p className="text-sm text-gray-500 mt-1">{exercise.notes}</p>}
+            {exercise.exercise_demo && (
+              <a
+                href={exercise.exercise_demo}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline mt-1"
+              >
+                <ExternalLink className="h-3 w-3" />
+                Demo
+              </a>
+            )}
+          </>
+        )}
+
+        {isEditMode && (
+          <div className="mt-3 space-y-2">
+            <div className="flex gap-2">
+              <div className="flex-1">
+                <label className="text-xs text-gray-500">Sets</label>
+                <Input
+                  type="number"
+                  min="0"
+                  value={sets}
+                  onChange={(e) => setSets(e.target.value)}
+                  placeholder="e.g. 3"
+                />
+              </div>
+              <div className="flex-1">
+                <label className="text-xs text-gray-500">Reps</label>
+                <Input
+                  value={reps}
+                  onChange={(e) => setReps(e.target.value)}
+                  placeholder="e.g. 8-10"
+                />
+              </div>
+              <div className="flex-1">
+                <label className="text-xs text-gray-500">Duration (s)</label>
+                <Input
+                  type="number"
+                  min="0"
+                  value={durationSeconds}
+                  onChange={(e) => setDurationSeconds(e.target.value)}
+                  placeholder="e.g. 30"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="text-xs text-gray-500">Notes</label>
+              <Textarea
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="Per-exercise notes..."
+                rows={2}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {isEditMode && (
+        <div className="flex-shrink-0 flex gap-1 mt-1">
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            onClick={handleSave}
+            disabled={isSaving}
+            aria-label="Save exercise"
+          >
+            <Save className="h-4 w-4" />
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            onClick={() => onRemove(exercise.id)}
+            className="text-red-500 hover:text-red-700 hover:bg-red-50"
+            aria-label="Remove exercise"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProgramBuilder/ProgramExerciseList.test.tsx
+++ b/src/components/ProgramBuilder/ProgramExerciseList.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ProgramExerciseList } from './ProgramExerciseList';
+import type { ProgramExercise } from '@/types/program';
+
+const exercises: ProgramExercise[] = [
+  {
+    id: 'pe-1',
+    exercise_id: 'ex-1',
+    exercise_name: 'Squat',
+    exercise_demo: null,
+    tags: ['strength'],
+    order_index: 0,
+    sets: 3,
+    reps: '8-10',
+    duration_seconds: null,
+    notes: null,
+  },
+  {
+    id: 'pe-2',
+    exercise_id: 'ex-2',
+    exercise_name: 'Deadlift',
+    exercise_demo: null,
+    tags: ['strength', 'posterior chain'],
+    order_index: 1,
+    sets: 4,
+    reps: '5',
+    duration_seconds: null,
+    notes: 'Keep back straight',
+  },
+];
+
+const defaultProps = {
+  onUpdate: vi.fn(),
+  onRemove: vi.fn(),
+  onReorder: vi.fn(),
+};
+
+describe('ProgramExerciseList', () => {
+  it('renders all exercises in order_index order', () => {
+    render(
+      <ProgramExerciseList
+        exercises={exercises}
+        isEditMode={false}
+        {...defaultProps}
+      />,
+    );
+
+    const items = screen.getAllByText(/Squat|Deadlift/);
+    expect(items[0]).toHaveTextContent('Squat');
+    expect(items[1]).toHaveTextContent('Deadlift');
+  });
+
+  it('shows "No exercises added yet." when empty in Edit mode', () => {
+    render(
+      <ProgramExerciseList
+        exercises={[]}
+        isEditMode={true}
+        {...defaultProps}
+      />,
+    );
+
+    expect(screen.getByText('No exercises added yet.')).toBeInTheDocument();
+  });
+
+  it('shows "This program has no exercises." when empty in View mode', () => {
+    render(
+      <ProgramExerciseList
+        exercises={[]}
+        isEditMode={false}
+        {...defaultProps}
+      />,
+    );
+
+    expect(screen.getByText('This program has no exercises.')).toBeInTheDocument();
+  });
+
+  it('renders drag handles in Edit mode', () => {
+    render(
+      <ProgramExerciseList
+        exercises={exercises}
+        isEditMode={true}
+        {...defaultProps}
+      />,
+    );
+
+    const dragHandles = screen.getAllByLabelText('Drag to reorder');
+    expect(dragHandles).toHaveLength(2);
+  });
+
+  it('does not render drag handles in View mode', () => {
+    render(
+      <ProgramExerciseList
+        exercises={exercises}
+        isEditMode={false}
+        {...defaultProps}
+      />,
+    );
+
+    expect(screen.queryByLabelText('Drag to reorder')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ProgramBuilder/ProgramExerciseList.tsx
+++ b/src/components/ProgramBuilder/ProgramExerciseList.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { ProgramExerciseItem } from './ProgramExerciseItem';
+import type { ProgramExercise, UpdateProgramExerciseDto, ReorderExercisesDto } from '@/types/program';
+
+type ProgramExerciseListProps = {
+  exercises: ProgramExercise[];
+  isEditMode: boolean;
+  onUpdate: (id: string, data: UpdateProgramExerciseDto) => Promise<void>;
+  onRemove: (id: string) => void;
+  onReorder: (data: ReorderExercisesDto) => Promise<void>;
+};
+
+type SortableExerciseItemProps = {
+  exercise: ProgramExercise;
+  isEditMode: boolean;
+  onUpdate: (id: string, data: UpdateProgramExerciseDto) => Promise<void>;
+  onRemove: (id: string) => void;
+};
+
+function SortableExerciseItem({
+  exercise,
+  isEditMode,
+  onUpdate,
+  onRemove,
+}: SortableExerciseItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: exercise.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <ProgramExerciseItem
+        exercise={exercise}
+        isEditMode={isEditMode}
+        dragHandleProps={{ ...attributes, ...listeners }}
+        onUpdate={onUpdate}
+        onRemove={onRemove}
+      />
+    </div>
+  );
+}
+
+export function ProgramExerciseList({
+  exercises,
+  isEditMode,
+  onUpdate,
+  onRemove,
+  onReorder,
+}: ProgramExerciseListProps) {
+  const sorted = [...exercises].sort((a, b) => a.order_index - b.order_index);
+
+  const sensors = useSensors(useSensor(PointerSensor));
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = sorted.findIndex((e) => e.id === active.id);
+    const newIndex = sorted.findIndex((e) => e.id === over.id);
+    const reordered = arrayMove(sorted, oldIndex, newIndex);
+
+    onReorder({
+      exercises: reordered.map((e, idx) => ({ id: e.id, order_index: idx })),
+    });
+  }
+
+  if (exercises.length === 0) {
+    return (
+      <p className="text-sm text-gray-400 text-center py-8">
+        {isEditMode ? 'No exercises added yet.' : 'This program has no exercises.'}
+      </p>
+    );
+  }
+
+  if (!isEditMode) {
+    return (
+      <div className="space-y-3">
+        {sorted.map((exercise) => (
+          <ProgramExerciseItem
+            key={exercise.id}
+            exercise={exercise}
+            isEditMode={false}
+            onUpdate={onUpdate}
+            onRemove={onRemove}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={sorted.map((e) => e.id)} strategy={verticalListSortingStrategy}>
+        <div className="space-y-3">
+          {sorted.map((exercise) => (
+            <SortableExerciseItem
+              key={exercise.id}
+              exercise={exercise}
+              isEditMode={isEditMode}
+              onUpdate={onUpdate}
+              onRemove={onRemove}
+            />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/src/components/ProgramBuilder/ProgramList.tsx
+++ b/src/components/ProgramBuilder/ProgramList.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from 'react';
+import { Plus } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ProgramClientGroup } from './ProgramClientGroup';
+import { ProgramCreateDialog } from './ProgramCreateDialog';
+import type { ProgramSummary, CreateProgramDto, Program } from '@/types/program';
+
+type ProgramListProps = {
+  userId: string;
+  programs: ProgramSummary[];
+  isLoading: boolean;
+  activeProgramId: string | null;
+  onSelectProgram: (id: string) => void;
+  onCreateProgram: (data: CreateProgramDto) => Promise<Program | null>;
+  onDeleteProgram: (id: string) => Promise<void>;
+};
+
+type ClientGroup = {
+  clientId: string;
+  clientName: string;
+  programs: ProgramSummary[];
+};
+
+function buildGroups(programs: ProgramSummary[], search: string): ClientGroup[] {
+  const q = search.toLowerCase();
+  const filtered = search
+    ? programs.filter(
+        (p) =>
+          p.name.toLowerCase().includes(q) ||
+          p.client_name.toLowerCase().includes(q),
+      )
+    : programs;
+
+  const map: Record<string, ClientGroup> = {};
+  for (const p of filtered) {
+    if (!map[p.client_id]) {
+      map[p.client_id] = { clientId: p.client_id, clientName: p.client_name, programs: [] };
+    }
+    map[p.client_id].programs.push(p);
+  }
+
+  return Object.values(map).sort((a, b) =>
+    a.clientName.localeCompare(b.clientName),
+  );
+}
+
+export function ProgramList({
+  userId,
+  programs,
+  isLoading,
+  activeProgramId,
+  onSelectProgram,
+  onCreateProgram,
+  onDeleteProgram,
+}: ProgramListProps) {
+  const [search, setSearch] = useState('');
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const groups = buildGroups(programs, search);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="p-3 border-b border-gray-200">
+        <Input
+          placeholder="Search by program or client..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {isLoading ? (
+          <div className="p-3 space-y-2">
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-16 w-full" />
+          </div>
+        ) : groups.length === 0 ? (
+          <p className="text-sm text-gray-500 text-center p-6">No programs found.</p>
+        ) : (
+          groups.map((group) => (
+            <ProgramClientGroup
+              key={group.clientId}
+              clientName={group.clientName}
+              programs={group.programs}
+              activeProgramId={activeProgramId}
+              onSelectProgram={onSelectProgram}
+              onDeleteProgram={onDeleteProgram}
+            />
+          ))
+        )}
+      </div>
+
+      <div className="p-3 border-t border-gray-200">
+        <Button className="w-full" onClick={() => setCreateOpen(true)}>
+          <Plus className="h-4 w-4 mr-2" />
+          New Program
+        </Button>
+      </div>
+
+      <ProgramCreateDialog
+        userId={userId}
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreate={onCreateProgram}
+      />
+    </div>
+  );
+}

--- a/src/components/ProgramBuilder/ProgramListItem.test.tsx
+++ b/src/components/ProgramBuilder/ProgramListItem.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ProgramListItem } from './ProgramListItem';
+import type { ProgramSummary } from '@/types/program';
+
+const mockProgram: ProgramSummary = {
+  id: 'prog-1',
+  name: 'Phase 1 Strength',
+  description: 'Foundation block',
+  status: 'DRAFT',
+  tags: [],
+  client_id: 'client-1',
+  client_name: 'Jane Doe',
+  exercise_count: 6,
+  created_at: '2026-05-24T10:00:00.000Z',
+  updated_at: '2026-05-24T10:00:00.000Z',
+};
+
+describe('ProgramListItem', () => {
+  it('renders program name, status badge, client name, and exercise count', () => {
+    render(
+      <ProgramListItem
+        program={mockProgram}
+        isActive={false}
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Phase 1 Strength')).toBeInTheDocument();
+    expect(screen.getByText('Draft')).toBeInTheDocument();
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+    expect(screen.getByText('6 exercises')).toBeInTheDocument();
+  });
+
+  it('calls onSelect when the row is clicked', () => {
+    const onSelect = vi.fn();
+    const { container } = render(
+      <ProgramListItem
+        program={mockProgram}
+        isActive={false}
+        onSelect={onSelect}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('[role="button"]') as Element);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows confirmation dialog before calling onDelete', () => {
+    const onDelete = vi.fn();
+    render(
+      <ProgramListItem
+        program={mockProgram}
+        isActive={false}
+        onSelect={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Delete program'));
+    expect(screen.getByText('Delete Program')).toBeInTheDocument();
+    expect(onDelete).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onDelete).toHaveBeenCalledWith('prog-1');
+  });
+
+  it('does not call onDelete when cancel is clicked in confirmation', () => {
+    const onDelete = vi.fn();
+    render(
+      <ProgramListItem
+        program={mockProgram}
+        isActive={false}
+        onSelect={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Delete program'));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('applies active styles when isActive is true', () => {
+    const { container } = render(
+      <ProgramListItem
+        program={mockProgram}
+        isActive={true}
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector('[role="button"]')).toHaveClass('bg-accent');
+  });
+});

--- a/src/components/ProgramBuilder/ProgramListItem.tsx
+++ b/src/components/ProgramBuilder/ProgramListItem.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import { Trash2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { ProgramStatusBadge } from './ProgramStatusBadge';
+import { ProgramTagList } from './ProgramTagList';
+import type { ProgramSummary } from '@/types/program';
+
+type ProgramListItemProps = {
+  program: ProgramSummary;
+  isActive: boolean;
+  onSelect: () => void;
+  onDelete: (id: string) => void;
+};
+
+export function ProgramListItem({
+  program,
+  isActive,
+  onSelect,
+  onDelete,
+}: ProgramListItemProps) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  function handleDeleteClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    setConfirmOpen(true);
+  }
+
+  function handleConfirmDelete() {
+    setConfirmOpen(false);
+    onDelete(program.id);
+  }
+
+  return (
+    <>
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onSelect}
+        onKeyDown={(e) => e.key === 'Enter' && onSelect()}
+        className={`w-full text-left p-3 border-b border-gray-100 hover:bg-gray-50 transition-colors flex items-start justify-between gap-2 cursor-pointer ${
+          isActive ? 'bg-accent' : ''
+        }`}
+      >
+        <div className="flex-1 min-w-0">
+          <p className="font-semibold text-sm text-gray-900 truncate">{program.name}</p>
+          <div className="flex items-center gap-2 mt-1 flex-wrap">
+            <ProgramStatusBadge status={program.status} />
+            <ProgramTagList tags={program.tags} size="sm" />
+          </div>
+          <p className="text-xs text-gray-500 mt-1 truncate">{program.client_name}</p>
+          <p className="text-xs text-gray-400 mt-0.5">
+            {program.exercise_count} {program.exercise_count === 1 ? 'exercise' : 'exercises'}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleDeleteClick}
+          className="flex-shrink-0 p-1 rounded hover:bg-red-50 text-gray-400 hover:text-red-500 transition-colors"
+          aria-label="Delete program"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      </div>
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Program</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete &ldquo;{program.name}&rdquo;? This action cannot be
+              undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmDelete}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/ProgramBuilder/ProgramStatusBadge.test.tsx
+++ b/src/components/ProgramBuilder/ProgramStatusBadge.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ProgramStatusBadge } from './ProgramStatusBadge';
+
+describe('ProgramStatusBadge', () => {
+  it('renders "Draft" label for DRAFT status', () => {
+    render(<ProgramStatusBadge status="DRAFT" />);
+    expect(screen.getByText('Draft')).toBeInTheDocument();
+  });
+
+  it('renders "Ready" label for READY status', () => {
+    render(<ProgramStatusBadge status="READY" />);
+    expect(screen.getByText('Ready')).toBeInTheDocument();
+  });
+
+  it('renders "In Progress" label for IN_PROGRESS status', () => {
+    render(<ProgramStatusBadge status="IN_PROGRESS" />);
+    expect(screen.getByText('In Progress')).toBeInTheDocument();
+  });
+
+  it('renders "Complete" label for COMPLETE status', () => {
+    render(<ProgramStatusBadge status="COMPLETE" />);
+    expect(screen.getByText('Complete')).toBeInTheDocument();
+  });
+
+  it('applies secondary variant for DRAFT', () => {
+    const { container } = render(<ProgramStatusBadge status="DRAFT" />);
+    expect(container.firstChild).toHaveClass('bg-gray-100');
+  });
+
+  it('applies green color class for READY', () => {
+    const { container } = render(<ProgramStatusBadge status="READY" />);
+    expect(container.firstChild).toHaveClass('bg-green-100');
+  });
+
+  it('applies blue color class for IN_PROGRESS', () => {
+    const { container } = render(<ProgramStatusBadge status="IN_PROGRESS" />);
+    expect(container.firstChild).toHaveClass('bg-blue-100');
+  });
+
+  it('applies purple color class for COMPLETE', () => {
+    const { container } = render(<ProgramStatusBadge status="COMPLETE" />);
+    expect(container.firstChild).toHaveClass('bg-purple-100');
+  });
+});

--- a/src/components/ProgramBuilder/ProgramStatusBadge.tsx
+++ b/src/components/ProgramBuilder/ProgramStatusBadge.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import type { ProgramStatus } from '@/types/program';
+
+type ProgramStatusBadgeProps = {
+  status: ProgramStatus;
+};
+
+const statusConfig: Record<ProgramStatus, { label: string; className: string }> = {
+  DRAFT: { label: 'Draft', className: '' },
+  READY: { label: 'Ready', className: 'bg-green-100 text-green-800 border-green-200' },
+  IN_PROGRESS: { label: 'In Progress', className: 'bg-blue-100 text-blue-800 border-blue-200' },
+  COMPLETE: { label: 'Complete', className: 'bg-purple-100 text-purple-800 border-purple-200' },
+};
+
+export function ProgramStatusBadge({ status }: ProgramStatusBadgeProps) {
+  const config = statusConfig[status];
+  return (
+    <Badge
+      variant={status === 'DRAFT' ? 'secondary' : 'outline'}
+      className={config.className}
+    >
+      {config.label}
+    </Badge>
+  );
+}

--- a/src/components/ProgramBuilder/ProgramTagList.tsx
+++ b/src/components/ProgramBuilder/ProgramTagList.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+
+type ProgramTagListProps = {
+  tags: string[];
+  size?: 'sm' | 'default';
+};
+
+export function ProgramTagList({ tags, size = 'default' }: ProgramTagListProps) {
+  if (tags.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {tags.map((tag) => (
+        <Badge
+          key={tag}
+          variant="secondary"
+          className={size === 'sm' ? 'text-[10px] px-1.5 py-0' : 'text-xs'}
+        >
+          {tag}
+        </Badge>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ProgramBuilder/TagInput.tsx
+++ b/src/components/ProgramBuilder/TagInput.tsx
@@ -1,0 +1,62 @@
+import React, { useState, type KeyboardEvent } from 'react';
+import { X } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+
+type TagInputProps = {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+  placeholder?: string;
+};
+
+export function TagInput({ tags, onChange, placeholder = 'Add a tag...' }: TagInputProps) {
+  const [value, setValue] = useState('');
+
+  function addTag(raw: string) {
+    const tag = raw.trim();
+    if (tag && !tags.includes(tag)) {
+      onChange([...tags, tag]);
+    }
+    setValue('');
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addTag(value);
+    } else if (e.key === 'Backspace' && !value && tags.length > 0) {
+      onChange(tags.slice(0, -1));
+    }
+  }
+
+  function removeTag(tag: string) {
+    onChange(tags.filter((t) => t !== tag));
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-1">
+        {tags.map((tag) => (
+          <Badge key={tag} variant="secondary" className="flex items-center gap-1 pr-1">
+            {tag}
+            <button
+              type="button"
+              onClick={() => removeTag(tag)}
+              className="ml-0.5 rounded-full hover:bg-gray-300 p-0.5"
+              aria-label={`Remove tag ${tag}`}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        ))}
+      </div>
+      <Input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+      />
+      <p className="text-xs text-gray-400">Press Enter or comma to add a tag</p>
+    </div>
+  );
+}

--- a/src/hooks/useDashboard.test.ts
+++ b/src/hooks/useDashboard.test.ts
@@ -1,5 +1,8 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { UserProvider } from '@/context/UserContext';
+import React from 'react';
 import { useDashboard } from './useDashboard';
 import * as dashboardApi from '@/lib/dashboardApi';
 import type { CoachDashboard } from '@/types/dashboard';
@@ -13,6 +16,14 @@ const mockDashboardData: CoachDashboard = {
   unscheduled_clients: [],
 };
 
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(
+    MemoryRouter,
+    null,
+    React.createElement(UserProvider, null, children),
+  );
+}
+
 describe('useDashboard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -20,13 +31,13 @@ describe('useDashboard', () => {
 
   it('starts in loading state', () => {
     vi.mocked(dashboardApi.getDashboard).mockResolvedValue(mockDashboardData);
-    const { result } = renderHook(() => useDashboard());
+    const { result } = renderHook(() => useDashboard(), { wrapper });
     expect(result.current.isLoading).toBe(true);
   });
 
   it('sets dashboard data on successful fetch', async () => {
     vi.mocked(dashboardApi.getDashboard).mockResolvedValue(mockDashboardData);
-    const { result } = renderHook(() => useDashboard());
+    const { result } = renderHook(() => useDashboard(), { wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
@@ -36,41 +47,38 @@ describe('useDashboard', () => {
 
   it('stops loading and leaves dashboard null on fetch failure', async () => {
     vi.mocked(dashboardApi.getDashboard).mockRejectedValue(new Error('Server error'));
-    const { result } = renderHook(() => useDashboard());
+    const { result } = renderHook(() => useDashboard(), { wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.dashboard).toBeNull();
   });
 
-  it('re-fetches when selectedDate changes', async () => {
+  it('calls getDashboard for multiple days on initial fetch', async () => {
     vi.mocked(dashboardApi.getDashboard).mockResolvedValue(mockDashboardData);
-    const { result } = renderHook(() => useDashboard());
+    const { result } = renderHook(() => useDashboard(), { wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(vi.mocked(dashboardApi.getDashboard)).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(dashboardApi.getDashboard)).toHaveBeenCalledWith(undefined);
+
+    expect(vi.mocked(dashboardApi.getDashboard).mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('re-fetches when refetch is called', async () => {
+    vi.mocked(dashboardApi.getDashboard).mockResolvedValue(mockDashboardData);
+    const { result } = renderHook(() => useDashboard(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const callCountAfterMount = vi.mocked(dashboardApi.getDashboard).mock.calls.length;
 
     await act(async () => {
-      result.current.setSelectedDate('2026-05-10');
+      await result.current.refetch();
     });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(vi.mocked(dashboardApi.getDashboard)).toHaveBeenCalledTimes(2);
-    expect(vi.mocked(dashboardApi.getDashboard)).toHaveBeenLastCalledWith('2026-05-10');
-  });
 
-  it('clears dashboard data when setSelectedDate is called', async () => {
-    vi.mocked(dashboardApi.getDashboard).mockResolvedValue(mockDashboardData);
-    const { result } = renderHook(() => useDashboard());
-
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.dashboard).toEqual(mockDashboardData);
-
-    act(() => {
-      result.current.setSelectedDate('2026-05-10');
-    });
-
-    expect(result.current.dashboard).toBeNull();
+    expect(vi.mocked(dashboardApi.getDashboard).mock.calls.length).toBeGreaterThan(
+      callCountAfterMount,
+    );
   });
 });

--- a/src/hooks/useProgramDetail.test.ts
+++ b/src/hooks/useProgramDetail.test.ts
@@ -1,0 +1,162 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { UserProvider } from '@/context/UserContext';
+import React from 'react';
+import { useProgramDetail } from './useProgramDetail';
+import * as programApi from '@/lib/programApi';
+import { ApiError } from '@/lib/api';
+import type { Program } from '@/types/program';
+
+vi.mock('@/lib/programApi');
+
+const mockProgram: Program = {
+  id: 'prog-1',
+  name: 'Phase 1 Strength',
+  description: 'Foundation block',
+  status: 'DRAFT',
+  tags: [],
+  client_id: 'client-1',
+  client_name: 'Jane Doe',
+  notes: null,
+  exercises: [],
+  created_at: '2026-05-24T10:00:00.000Z',
+  updated_at: '2026-05-24T10:00:00.000Z',
+};
+
+const completeProgram: Program = {
+  ...mockProgram,
+  id: 'prog-complete',
+  status: 'COMPLETE',
+};
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(
+    MemoryRouter,
+    null,
+    React.createElement(UserProvider, null, children),
+  );
+}
+
+describe('useProgramDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts loading and loads program data', async () => {
+    vi.mocked(programApi.getProgramById).mockResolvedValue(mockProgram);
+    const { result } = renderHook(() => useProgramDetail('prog-1'), { wrapper });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.program).toEqual(mockProgram);
+  });
+
+  it('returns null program when no programId is provided', async () => {
+    const { result } = renderHook(() => useProgramDetail(null), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.program).toBeNull();
+    expect(vi.mocked(programApi.getProgramById)).not.toHaveBeenCalled();
+  });
+
+  it('resets edit mode to false when programId changes', async () => {
+    vi.mocked(programApi.getProgramById).mockResolvedValue(mockProgram);
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string | null }) => useProgramDetail(id),
+      { wrapper, initialProps: { id: 'prog-1' } },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.setIsEditMode(true);
+    });
+
+    expect(result.current.isEditMode).toBe(true);
+
+    vi.mocked(programApi.getProgramById).mockResolvedValue({
+      ...mockProgram,
+      id: 'prog-2',
+      name: 'Phase 2',
+    });
+
+    rerender({ id: 'prog-2' });
+
+    expect(result.current.isEditMode).toBe(false);
+  });
+
+  it('ignores setIsEditMode(true) when program status is COMPLETE', async () => {
+    vi.mocked(programApi.getProgramById).mockResolvedValue(completeProgram);
+    const { result } = renderHook(() => useProgramDetail('prog-complete'), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.program?.status).toBe('COMPLETE');
+
+    act(() => {
+      result.current.setIsEditMode(true);
+    });
+
+    expect(result.current.isEditMode).toBe(false);
+  });
+
+  it('triggers a browser download on successful exportProgram', async () => {
+    vi.mocked(programApi.getProgramById).mockResolvedValue({
+      ...mockProgram,
+      status: 'READY',
+    });
+
+    const mockBlob = new Blob(['pdf content'], { type: 'application/pdf' });
+    vi.mocked(programApi.exportProgramAsPdf).mockResolvedValue(mockBlob);
+
+    const mockObjectUrl = 'blob:http://localhost/fake-url';
+    URL.createObjectURL = vi.fn().mockReturnValue(mockObjectUrl);
+    URL.revokeObjectURL = vi.fn();
+
+    const { result } = renderHook(() => useProgramDetail('prog-1'), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const mockClick = vi.fn();
+    const mockAnchor = { href: '', download: '', click: mockClick } as unknown as HTMLAnchorElement;
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'a') return mockAnchor;
+      return originalCreateElement(tagName);
+    });
+
+    await act(async () => {
+      await result.current.exportProgram();
+    });
+
+    expect(URL.createObjectURL).toHaveBeenCalledWith(mockBlob);
+    expect(mockClick).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(mockObjectUrl);
+
+    vi.restoreAllMocks();
+  });
+
+  it('shows toast on 403 during exportProgram', async () => {
+    vi.mocked(programApi.getProgramById).mockResolvedValue({
+      ...mockProgram,
+      status: 'DRAFT',
+    });
+    vi.mocked(programApi.exportProgramAsPdf).mockRejectedValue(
+      new ApiError(403, 'Forbidden'),
+    );
+
+    const { result } = renderHook(() => useProgramDetail('prog-1'), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.exportProgram();
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0].message).toBe(
+      'Only programs marked as Ready can be exported.',
+    );
+  });
+});

--- a/src/hooks/useProgramDetail.ts
+++ b/src/hooks/useProgramDetail.ts
@@ -1,0 +1,211 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useUser } from '@/context/UserContext';
+import { ApiError } from '@/lib/api';
+import * as programApi from '@/lib/programApi';
+import type {
+  Program,
+  UpdateProgramDto,
+  AddExerciseDto,
+  UpdateProgramExerciseDto,
+  ReorderExercisesDto,
+} from '@/types/program';
+
+export type ToastMessage = {
+  id: number;
+  message: string;
+  type: 'error' | 'success';
+};
+
+export function useProgramDetail(programId: string | null) {
+  const navigate = useNavigate();
+  const { clearUser } = useUser();
+
+  const [program, setProgram] = useState<Program | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isEditMode, setIsEditModeState] = useState(false);
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+  const toastIdRef = useRef(0);
+
+  const addToast = useCallback((message: string, type: 'error' | 'success' = 'error') => {
+    const id = ++toastIdRef.current;
+    setToasts((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 5000);
+  }, []);
+
+  const dismissToast = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const setIsEditMode = useCallback(
+    (value: boolean) => {
+      if (value && program?.status === 'COMPLETE') return;
+      setIsEditModeState(value);
+    },
+    [program?.status],
+  );
+
+  const handleApiError = useCallback(
+    (err: unknown) => {
+      if (err instanceof ApiError) {
+        if (err.status === 401) {
+          localStorage.removeItem('auth_token');
+          clearUser();
+          navigate('/', { replace: true });
+          return;
+        }
+        if (err.status === 403) {
+          addToast("You don't have permission to do that.");
+          return;
+        }
+        if (err.message === 'Network error or server unreachable') {
+          addToast('Unable to reach the server. Check your connection.');
+        } else {
+          addToast('Something went wrong. Please try again.');
+        }
+      } else {
+        addToast('Something went wrong. Please try again.');
+      }
+    },
+    [addToast, clearUser, navigate],
+  );
+
+  const fetchProgram = useCallback(async () => {
+    if (!programId) return;
+    setIsLoading(true);
+    try {
+      const data = await programApi.getProgramById(programId);
+      setProgram(data);
+    } catch (err) {
+      handleApiError(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [programId, handleApiError]);
+
+  useEffect(() => {
+    setIsEditModeState(false);
+    setProgram(null);
+    fetchProgram();
+    // fetchProgram is stable when programId is stable; only run on programId change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [programId]);
+
+  const updateProgram = useCallback(
+    async (data: UpdateProgramDto): Promise<void> => {
+      if (!programId) return;
+      try {
+        const updated = await programApi.updateProgram(programId, data);
+        setProgram(updated);
+        addToast('Program updated.', 'success');
+      } catch (err) {
+        handleApiError(err);
+        throw err;
+      }
+    },
+    [programId, handleApiError, addToast],
+  );
+
+  const addExercise = useCallback(
+    async (data: AddExerciseDto): Promise<void> => {
+      if (!programId) return;
+      try {
+        await programApi.addExerciseToProgram(programId, data);
+        await fetchProgram();
+        addToast('Exercise added.', 'success');
+      } catch (err) {
+        handleApiError(err);
+        throw err;
+      }
+    },
+    [programId, fetchProgram, handleApiError, addToast],
+  );
+
+  const updateExercise = useCallback(
+    async (programExerciseId: string, data: UpdateProgramExerciseDto): Promise<void> => {
+      if (!programId) return;
+      try {
+        const updated = await programApi.updateProgramExercise(
+          programId,
+          programExerciseId,
+          data,
+        );
+        setProgram((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            exercises: prev.exercises.map((e) => (e.id === programExerciseId ? updated : e)),
+          };
+        });
+        addToast('Exercise updated.', 'success');
+      } catch (err) {
+        handleApiError(err);
+        throw err;
+      }
+    },
+    [programId, handleApiError, addToast],
+  );
+
+  const removeExercise = useCallback(
+    async (programExerciseId: string): Promise<void> => {
+      if (!programId) return;
+      try {
+        await programApi.removeProgramExercise(programId, programExerciseId);
+        await fetchProgram();
+        addToast('Exercise removed.', 'success');
+      } catch (err) {
+        handleApiError(err);
+        throw err;
+      }
+    },
+    [programId, fetchProgram, handleApiError, addToast],
+  );
+
+  const reorderExercises = useCallback(
+    async (data: ReorderExercisesDto): Promise<void> => {
+      if (!programId) return;
+      try {
+        const updated = await programApi.reorderProgramExercises(programId, data);
+        setProgram(updated);
+      } catch (err) {
+        handleApiError(err);
+        throw err;
+      }
+    },
+    [programId, handleApiError],
+  );
+
+  const exportProgram = useCallback(async (): Promise<void> => {
+    if (!programId || !program) return;
+    try {
+      const blob = await programApi.exportProgramAsPdf(programId);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${program.name}.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        addToast('Only programs marked as Ready can be exported.');
+      } else {
+        handleApiError(err);
+      }
+    }
+  }, [programId, program, addToast, handleApiError]);
+
+  return {
+    program,
+    isLoading,
+    isEditMode,
+    setIsEditMode,
+    updateProgram,
+    addExercise,
+    updateExercise,
+    removeExercise,
+    reorderExercises,
+    exportProgram,
+    toasts,
+    dismissToast,
+  };
+}

--- a/src/hooks/usePrograms.test.ts
+++ b/src/hooks/usePrograms.test.ts
@@ -1,0 +1,130 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { UserProvider } from '@/context/UserContext';
+import React from 'react';
+import { usePrograms } from './usePrograms';
+import * as programApi from '@/lib/programApi';
+import type { ProgramSummary } from '@/types/program';
+
+vi.mock('@/lib/programApi');
+
+const mockPrograms: ProgramSummary[] = [
+  {
+    id: 'prog-1',
+    name: 'Phase 1',
+    description: null,
+    status: 'DRAFT',
+    tags: [],
+    client_id: 'client-1',
+    client_name: 'Jane Doe',
+    exercise_count: 3,
+    created_at: '2026-05-24T10:00:00.000Z',
+    updated_at: '2026-05-24T10:00:00.000Z',
+  },
+  {
+    id: 'prog-2',
+    name: 'Phase 2',
+    description: null,
+    status: 'READY',
+    tags: [],
+    client_id: 'client-2',
+    client_name: 'Bob Smith',
+    exercise_count: 5,
+    created_at: '2026-05-24T10:00:00.000Z',
+    updated_at: '2026-05-24T10:00:00.000Z',
+  },
+];
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(
+    MemoryRouter,
+    null,
+    React.createElement(UserProvider, null, children),
+  );
+}
+
+describe('usePrograms', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts in loading state and loads programs', async () => {
+    vi.mocked(programApi.getPrograms).mockResolvedValue(mockPrograms);
+    const { result } = renderHook(() => usePrograms(), { wrapper });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.programs).toEqual(mockPrograms);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error on fetch failure', async () => {
+    vi.mocked(programApi.getPrograms).mockRejectedValue(new Error('Server error'));
+    const { result } = renderHook(() => usePrograms(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.programs).toEqual([]);
+  });
+
+  it('triggers a re-fetch with the new filter when setSelectedClientId is called', async () => {
+    vi.mocked(programApi.getPrograms).mockResolvedValue(mockPrograms);
+    const { result } = renderHook(() => usePrograms(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(vi.mocked(programApi.getPrograms)).toHaveBeenCalledWith(undefined);
+
+    vi.mocked(programApi.getPrograms).mockResolvedValue([mockPrograms[0]]);
+
+    act(() => {
+      result.current.setSelectedClientId('client-1');
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(vi.mocked(programApi.getPrograms)).toHaveBeenLastCalledWith('client-1');
+  });
+
+  it('clears activeProgramId when the deleted program was active', async () => {
+    vi.mocked(programApi.getPrograms).mockResolvedValue(mockPrograms);
+    vi.mocked(programApi.deleteProgram).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => usePrograms(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.setActiveProgramId('prog-1');
+    });
+
+    expect(result.current.activeProgramId).toBe('prog-1');
+
+    await act(async () => {
+      await result.current.deleteProgram('prog-1');
+    });
+
+    expect(result.current.activeProgramId).toBeNull();
+  });
+
+  it('does not clear activeProgramId when a different program is deleted', async () => {
+    vi.mocked(programApi.getPrograms).mockResolvedValue(mockPrograms);
+    vi.mocked(programApi.deleteProgram).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => usePrograms(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.setActiveProgramId('prog-1');
+    });
+
+    await act(async () => {
+      await result.current.deleteProgram('prog-2');
+    });
+
+    expect(result.current.activeProgramId).toBe('prog-1');
+  });
+});

--- a/src/hooks/usePrograms.ts
+++ b/src/hooks/usePrograms.ts
@@ -1,0 +1,147 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useUser } from '@/context/UserContext';
+import { ApiError } from '@/lib/api';
+import * as programApi from '@/lib/programApi';
+import type { ProgramSummary, Program, CreateProgramDto } from '@/types/program';
+
+export type ToastMessage = {
+  id: number;
+  message: string;
+  type: 'error' | 'success';
+};
+
+export function usePrograms() {
+  const navigate = useNavigate();
+  const { clearUser } = useUser();
+
+  const [programs, setPrograms] = useState<ProgramSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedClientId, setSelectedClientIdState] = useState<string | undefined>(undefined);
+  const [activeProgramId, setActiveProgramId] = useState<string | null>(null);
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+  const toastIdRef = useRef(0);
+
+  const addToast = useCallback((message: string, type: 'error' | 'success' = 'error') => {
+    const id = ++toastIdRef.current;
+    setToasts((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 5000);
+  }, []);
+
+  const dismissToast = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const fetchPrograms = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await programApi.getPrograms(selectedClientId);
+      setPrograms(data);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 401) {
+          localStorage.removeItem('auth_token');
+          clearUser();
+          navigate('/', { replace: true });
+          return;
+        }
+        if (err.message === 'Network error or server unreachable') {
+          addToast('Unable to reach the server. Check your connection.');
+        } else {
+          addToast('Something went wrong. Please try again.');
+        }
+      } else {
+        addToast('Something went wrong. Please try again.');
+      }
+      setError('Failed to load programs.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [selectedClientId, addToast, clearUser, navigate]);
+
+  useEffect(() => {
+    fetchPrograms();
+  }, [fetchPrograms]);
+
+  const setSelectedClientId = useCallback((clientId: string | undefined) => {
+    setPrograms([]);
+    setSelectedClientIdState(clientId);
+  }, []);
+
+  const createProgram = useCallback(
+    async (data: CreateProgramDto): Promise<Program | null> => {
+      try {
+        const created = await programApi.createProgram(data);
+        await fetchPrograms();
+        setActiveProgramId(created.id);
+        addToast('Program created.', 'success');
+        return created;
+      } catch (err) {
+        if (err instanceof ApiError) {
+          if (err.status === 401) {
+            localStorage.removeItem('auth_token');
+            clearUser();
+            navigate('/', { replace: true });
+            return null;
+          }
+          if (err.message === 'Network error or server unreachable') {
+            addToast('Unable to reach the server. Check your connection.');
+          } else {
+            addToast('Something went wrong. Please try again.');
+          }
+        } else {
+          addToast('Something went wrong. Please try again.');
+        }
+        return null;
+      }
+    },
+    [fetchPrograms, addToast, clearUser, navigate],
+  );
+
+  const deleteProgram = useCallback(
+    async (id: string): Promise<void> => {
+      try {
+        await programApi.deleteProgram(id);
+        if (activeProgramId === id) {
+          setActiveProgramId(null);
+        }
+        await fetchPrograms();
+        addToast('Program deleted.', 'success');
+      } catch (err) {
+        if (err instanceof ApiError) {
+          if (err.status === 401) {
+            localStorage.removeItem('auth_token');
+            clearUser();
+            navigate('/', { replace: true });
+            return;
+          }
+          if (err.message === 'Network error or server unreachable') {
+            addToast('Unable to reach the server. Check your connection.');
+          } else {
+            addToast('Something went wrong. Please try again.');
+          }
+        } else {
+          addToast('Something went wrong. Please try again.');
+        }
+      }
+    },
+    [activeProgramId, fetchPrograms, addToast, clearUser, navigate],
+  );
+
+  return {
+    programs,
+    isLoading,
+    error,
+    selectedClientId,
+    setSelectedClientId,
+    activeProgramId,
+    setActiveProgramId,
+    createProgram,
+    deleteProgram,
+    refetch: fetchPrograms,
+    toasts,
+    dismissToast,
+  };
+}

--- a/src/lib/programApi.ts
+++ b/src/lib/programApi.ts
@@ -1,0 +1,93 @@
+import { apiRequest, ApiError } from './api';
+import type {
+  Program,
+  ProgramSummary,
+  ProgramExercise,
+  CreateProgramDto,
+  UpdateProgramDto,
+  AddExerciseDto,
+  UpdateProgramExerciseDto,
+  ReorderExercisesDto,
+} from '@/types/program';
+
+export async function getPrograms(clientId?: string): Promise<ProgramSummary[]> {
+  const params = clientId ? `?client_id=${encodeURIComponent(clientId)}` : '';
+  return apiRequest<ProgramSummary[]>(`/programs${params}`);
+}
+
+export async function createProgram(data: CreateProgramDto): Promise<Program> {
+  return apiRequest<Program>('/programs', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function getProgramById(id: string): Promise<Program> {
+  return apiRequest<Program>(`/programs/${id}`);
+}
+
+export async function updateProgram(id: string, data: UpdateProgramDto): Promise<Program> {
+  return apiRequest<Program>(`/programs/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteProgram(id: string): Promise<void> {
+  return apiRequest<void>(`/programs/${id}`, { method: 'DELETE' });
+}
+
+export async function addExerciseToProgram(
+  programId: string,
+  data: AddExerciseDto,
+): Promise<ProgramExercise> {
+  return apiRequest<ProgramExercise>(`/programs/${programId}/exercises`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateProgramExercise(
+  programId: string,
+  programExerciseId: string,
+  data: UpdateProgramExerciseDto,
+): Promise<ProgramExercise> {
+  return apiRequest<ProgramExercise>(
+    `/programs/${programId}/exercises/${programExerciseId}`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    },
+  );
+}
+
+export async function removeProgramExercise(
+  programId: string,
+  programExerciseId: string,
+): Promise<void> {
+  return apiRequest<void>(
+    `/programs/${programId}/exercises/${programExerciseId}`,
+    { method: 'DELETE' },
+  );
+}
+
+export async function reorderProgramExercises(
+  programId: string,
+  data: ReorderExercisesDto,
+): Promise<Program> {
+  return apiRequest<Program>(`/programs/${programId}/exercises/reorder`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function exportProgramAsPdf(programId: string): Promise<Blob> {
+  const token = localStorage.getItem('auth_token');
+  const response = await fetch(`/api/programs/${programId}/export`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!response.ok) {
+    throw new ApiError(response.status, `HTTP error! status: ${response.status}`);
+  }
+  return response.blob();
+}

--- a/src/pages/ProgramBuilder.tsx
+++ b/src/pages/ProgramBuilder.tsx
@@ -1,229 +1,163 @@
 import React, { useState } from 'react';
-import { SearchIcon, PlusIcon, SaveIcon, FolderIcon, TagIcon, CopyIcon, TrashIcon } from 'lucide-react';
-import ExerciseCard from '../components/ProgramBuilder/ExerciseCard';
-import TemplateBuilder from '../components/ProgramBuilder/TemplateBuilder';
-import { Exercise } from '../utils/mockData';
-const ProgramBuilder = () => {
-  const [activeTab, setActiveTab] = useState<'exercises' | 'templates'>('exercises');
-  const [searchTerm, setSearchTerm] = useState('');
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const [selectedProgram, setSelectedProgram] = useState<number | null>(null);
-  // Mock exercise data
-  const exercises: Exercise[] = [{
-    id: 1,
-    name: 'Barbell Back Squat',
-    category: 'strength',
-    muscle: 'Quadriceps',
-    difficulty: 'intermediate',
-    equipment: 'Barbell',
-    description: 'A compound exercise that targets the quadriceps, hamstrings, and glutes.',
-    image: 'https://images.unsplash.com/photo-1541534741688-6078c6bfb5c5?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80',
-    tags: ['strength', 'lower body', 'compound']
-  }, {
-    id: 2,
-    name: 'Romanian Deadlift',
-    category: 'strength',
-    muscle: 'Hamstrings',
-    difficulty: 'intermediate',
-    equipment: 'Barbell',
-    description: 'A hip-hinge movement that targets the posterior chain.',
-    image: 'https://images.unsplash.com/photo-1598971639058-fab3c3109a00?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80',
-    tags: ['strength', 'lower body', 'hinge']
-  }, {
-    id: 3,
-    name: 'Bench Press',
-    category: 'strength',
-    muscle: 'Chest',
-    difficulty: 'intermediate',
-    equipment: 'Barbell',
-    description: 'A horizontal pressing movement that targets the chest, shoulders, and triceps.',
-    image: 'https://images.unsplash.com/photo-1571019614242-c5c5dee9f50b?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80',
-    tags: ['strength', 'upper body', 'push']
-  }, {
-    id: 4,
-    name: 'Pull-up',
-    category: 'strength',
-    muscle: 'Back',
-    difficulty: 'advanced',
-    equipment: 'Pull-up Bar',
-    description: 'A vertical pulling movement that targets the back and biceps.',
-    image: 'https://images.unsplash.com/photo-1598971639058-fab3c3109a00?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80',
-    tags: ['strength', 'upper body', 'pull']
-  }, {
-    id: 5,
-    name: 'Hip Mobility Flow',
-    category: 'mobility',
-    muscle: 'Hips',
-    difficulty: 'beginner',
-    equipment: 'None',
-    description: 'A series of movements to improve hip mobility and function.',
-    image: 'https://images.unsplash.com/photo-1599447292180-45fd84092ef4?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80',
-    tags: ['mobility', 'lower body', 'recovery']
-  }, {
-    id: 6,
-    name: 'Shoulder Dislocates',
-    category: 'mobility',
-    muscle: 'Shoulders',
-    difficulty: 'beginner',
-    equipment: 'Resistance Band',
-    description: 'An exercise to improve shoulder mobility and function.',
-    image: 'https://images.unsplash.com/photo-1541534741688-6078c6bfb5c5?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80',
-    tags: ['mobility', 'upper body', 'prehab']
-  }, {
-    id: 7,
-    name: 'Ankle Mobility Routine',
-    category: 'rehab',
-    muscle: 'Ankles',
-    difficulty: 'beginner',
-    equipment: 'None',
-    description: 'A series of exercises to improve ankle mobility after injury.',
-    image: 'https://images.unsplash.com/photo-1571019614242-c5c5dee9f50b?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80',
-    tags: ['rehab', 'lower body', 'recovery']
-  }, {
-    id: 8,
-    name: 'Rotator Cuff Strengthening',
-    category: 'rehab',
-    muscle: 'Shoulders',
-    difficulty: 'beginner',
-    equipment: 'Dumbbells',
-    description: 'Exercises to strengthen the rotator cuff muscles.',
-    image: 'https://images.unsplash.com/photo-1599447292180-45fd84092ef4?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80',
-    tags: ['rehab', 'upper body', 'prehab']
-  }];
-  // Mock template programs
-  const templatePrograms = [{
-    id: 1,
-    name: 'Beginner Strength Program',
-    description: 'A 4-week program for beginners focusing on building foundational strength.',
-    category: 'strength',
-    exercises: [1, 2, 3, 4],
-    createdAt: '2023-04-10'
-  }, {
-    id: 2,
-    name: 'Mobility Restoration',
-    description: 'A comprehensive mobility program targeting common restrictions.',
-    category: 'mobility',
-    exercises: [5, 6],
-    createdAt: '2023-05-22'
-  }, {
-    id: 3,
-    name: 'Post-Injury Rehab',
-    description: 'Rehabilitation program for common injuries.',
-    category: 'rehab',
-    exercises: [7, 8],
-    createdAt: '2023-06-15'
-  }];
-  // Filter exercises based on search term and category
-  const filteredExercises = exercises.filter(exercise => {
-    const matchesSearch = exercise.name.toLowerCase().includes(searchTerm.toLowerCase()) || exercise.tags.some(tag => tag.toLowerCase().includes(searchTerm.toLowerCase()));
-    const matchesCategory = selectedCategory ? exercise.category === selectedCategory : true;
-    return matchesSearch && matchesCategory;
-  });
-  // Get unique categories for filter
-  const categories = Array.from(new Set(exercises.map(exercise => exercise.category)));
-  return <div className="h-full flex flex-col">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-800">Program Builder</h1>
-        {/* <p className="text-gray-600">
-          Create and manage exercise programs for your clients
-        </p> */}
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useUser } from '@/context/UserContext';
+import { usePrograms } from '@/hooks/usePrograms';
+import { useProgramDetail } from '@/hooks/useProgramDetail';
+import { ProgramList } from '@/components/ProgramBuilder/ProgramList';
+import { ProgramBuilderHeader } from '@/components/ProgramBuilder/ProgramBuilderHeader';
+import { ProgramExerciseList } from '@/components/ProgramBuilder/ProgramExerciseList';
+import { AddExerciseSheet } from '@/components/ProgramBuilder/AddExerciseSheet';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
+import { Plus } from 'lucide-react';
+
+export default function ProgramBuilderPage() {
+  const { userId } = useUser();
+
+  const {
+    programs,
+    isLoading: listLoading,
+    selectedClientId,
+    setSelectedClientId,
+    activeProgramId,
+    setActiveProgramId,
+    createProgram,
+    deleteProgram,
+    toasts: listToasts,
+    dismissToast: dismissListToast,
+  } = usePrograms();
+
+  const {
+    program,
+    isLoading: detailLoading,
+    isEditMode,
+    setIsEditMode,
+    updateProgram,
+    addExercise,
+    updateExercise,
+    removeExercise,
+    reorderExercises,
+    exportProgram,
+    toasts: detailToasts,
+    dismissToast: dismissDetailToast,
+  } = useProgramDetail(activeProgramId);
+
+  const [addExerciseSheetOpen, setAddExerciseSheetOpen] = useState(false);
+
+  if (!userId) return null;
+
+  return (
+    <div className="h-full flex gap-0">
+      <div className="w-80 flex-shrink-0 border-r border-gray-200 flex flex-col h-full">
+        <ProgramList
+          userId={userId}
+          programs={programs}
+          isLoading={listLoading}
+          selectedClientId={selectedClientId}
+          onClientFilterChange={setSelectedClientId}
+          activeProgramId={activeProgramId}
+          onSelectProgram={setActiveProgramId}
+          onCreateProgram={createProgram}
+          onDeleteProgram={deleteProgram}
+        />
       </div>
-      <div className="bg-white rounded-lg shadow flex-1 flex flex-col">
-        <div className="border-b border-gray-200">
-          <div className="flex">
-            <button className={`px-6 py-4 font-medium text-sm ${activeTab === 'exercises' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-gray-500 hover:text-gray-700'}`} onClick={() => setActiveTab('exercises')}>
-              Exercise Library
-            </button>
-            <button className={`px-6 py-4 font-medium text-sm ${activeTab === 'templates' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-gray-500 hover:text-gray-700'}`} onClick={() => setActiveTab('templates')}>
-              Program Templates
+
+      <div className="flex-1 flex flex-col overflow-hidden">
+        {program ? (
+          <>
+            <ProgramBuilderHeader
+              program={program}
+              isEditMode={isEditMode}
+              onToggleEditMode={() => setIsEditMode(!isEditMode)}
+              onUpdate={updateProgram}
+              onExport={exportProgram}
+            />
+            <div className="flex-1 overflow-y-auto p-6">
+              <ProgramExerciseList
+                exercises={program.exercises}
+                isEditMode={isEditMode}
+                onUpdate={updateExercise}
+                onRemove={removeExercise}
+                onReorder={reorderExercises}
+              />
+              {isEditMode && (
+                <div className="mt-4">
+                  <Button
+                    variant="outline"
+                    onClick={() => setAddExerciseSheetOpen(true)}
+                  >
+                    <Plus className="h-4 w-4 mr-2" />
+                    Add Exercise
+                  </Button>
+                </div>
+              )}
+            </div>
+            <AddExerciseSheet
+              userId={userId}
+              programId={program.id}
+              open={addExerciseSheetOpen}
+              onOpenChange={setAddExerciseSheetOpen}
+              onAdd={addExercise}
+            />
+          </>
+        ) : (
+          <div className="flex-1 flex items-center justify-center text-gray-400">
+            {listLoading || detailLoading ? (
+              <div className="space-y-3 w-64">
+                <Skeleton className="h-6 w-full" />
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-4 w-1/2" />
+              </div>
+            ) : (
+              <p>Select a program from the sidebar or create a new one.</p>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
+        {listToasts.map((toast) => (
+          <div
+            key={`list-${toast.id}`}
+            className={cn(
+              'pointer-events-auto flex items-start gap-3 rounded-lg border px-4 py-3 shadow-lg text-sm max-w-sm',
+              toast.type === 'error'
+                ? 'bg-red-50 border-red-200 text-red-800'
+                : 'bg-green-50 border-green-200 text-green-800',
+            )}
+          >
+            <span className="flex-1">{toast.message}</span>
+            <button
+              onClick={() => dismissListToast(toast.id)}
+              className="flex-shrink-0 opacity-70 hover:opacity-100"
+              aria-label="Dismiss"
+            >
+              <X className="h-4 w-4" />
             </button>
           </div>
-        </div>
-        {activeTab === 'exercises' ? <div className="flex-1 flex flex-col">
-            <div className="p-4 border-b border-gray-200 flex flex-wrap items-center justify-between gap-4">
-              <div className="relative flex-1 max-w-md">
-                <input type="text" placeholder="Search exercises..." value={searchTerm} onChange={e => setSearchTerm(e.target.value)} className="w-full pl-10 pr-4 py-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent" />
-                <SearchIcon size={18} className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
-              </div>
-              <div className="flex items-center space-x-2">
-                <span className="text-sm text-gray-600">Filter:</span>
-                <div className="flex space-x-1">
-                  {categories.map(category => <button key={category} onClick={() => setSelectedCategory(selectedCategory === category ? null : category)} className={`px-3 py-1 text-sm rounded-md ${selectedCategory === category ? category === 'strength' ? 'bg-tan-100 text-blue-800' : category === 'mobility' ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800' : 'bg-gray-100 text-gray-800 hover:bg-gray-200'}`}>
-                      {category.charAt(0).toUpperCase() + category.slice(1)}
-                    </button>)}
-                </div>
-                <button className="flex items-center px-3 py-2 bg-tan-600 text-white rounded-md text-sm font-medium hover:bg-tan-700 ml-2">
-                  <PlusIcon size={16} className="mr-1" />
-                  Add Exercise
-                </button>
-              </div>
-            </div>
-            <div className="flex-1 p-6 overflow-y-auto">
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-                {filteredExercises.map(exercise => <ExerciseCard key={exercise.id} exercise={exercise} />)}
-              </div>
-            </div>
-          </div> : <div className="flex-1 flex">
-            <div className="w-80 border-r border-gray-200 flex flex-col">
-              <div className="p-4 border-b border-gray-200">
-                <div className="relative">
-                  <input type="text" placeholder="Search templates..." className="w-full pl-10 pr-4 py-2 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent" />
-                  <SearchIcon size={18} className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
-                </div>
-              </div>
-              <div className="flex-1 overflow-y-auto">
-                {templatePrograms.map(program => <button key={program.id} className={`w-full text-left p-4 border-b border-gray-200 hover:bg-gray-50 ${selectedProgram === program.id ? 'bg-tan-50' : ''}`} onClick={() => setSelectedProgram(program.id)}>
-                    <div className="flex items-start">
-                      <div className={`p-2 rounded-md mr-3 ${program.category === 'strength' ? 'bg-tan-100' : program.category === 'mobility' ? 'bg-green-100' : 'bg-yellow-100'}`}>
-                        <FolderIcon size={16} className={program.category === 'strength' ? 'text-blue-600' : program.category === 'mobility' ? 'text-green-600' : 'text-yellow-600'} />
-                      </div>
-                      <div>
-                        <h3 className="font-medium text-sm">{program.name}</h3>
-                        <p className="text-xs text-gray-500 mt-1 line-clamp-2">
-                          {program.description}
-                        </p>
-                        <div className="flex items-center mt-2">
-                          <TagIcon size={12} className="text-gray-400 mr-1" />
-                          <span className="text-xs text-gray-500">
-                            {program.category}
-                          </span>
-                          <span className="mx-2 text-gray-300">•</span>
-                          <span className="text-xs text-gray-500">
-                            {program.exercises.length} exercises
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </button>)}
-              </div>
-              <div className="p-4 border-t border-gray-200">
-                <button className="w-full flex items-center justify-center px-4 py-2 bg-tan-600 text-white rounded-md text-sm font-medium hover:bg-tan-700">
-                  <PlusIcon size={16} className="mr-1" />
-                  New Template
-                </button>
-              </div>
-            </div>
-            <div className="flex-1 flex flex-col">
-              {selectedProgram ? <TemplateBuilder program={templatePrograms.find(p => p.id === selectedProgram)!} exercises={exercises} /> : <div className="flex-1 flex items-center justify-center">
-                  <div className="text-center">
-                    <div className="mx-auto w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mb-4">
-                      <FolderIcon size={24} className="text-gray-400" />
-                    </div>
-                    <h3 className="text-lg font-medium text-gray-800">
-                      No Template Selected
-                    </h3>
-                    <p className="text-gray-500 mt-2 max-w-sm">
-                      Select a template from the sidebar or create a new one to
-                      get started.
-                    </p>
-                    <button className="mt-4 px-4 py-2 bg-tan-600 text-white rounded-md text-sm font-medium hover:bg-tan-700">
-                      Create New Template
-                    </button>
-                  </div>
-                </div>}
-            </div>
-          </div>}
+        ))}
+        {detailToasts.map((toast) => (
+          <div
+            key={`detail-${toast.id}`}
+            className={cn(
+              'pointer-events-auto flex items-start gap-3 rounded-lg border px-4 py-3 shadow-lg text-sm max-w-sm',
+              toast.type === 'error'
+                ? 'bg-red-50 border-red-200 text-red-800'
+                : 'bg-green-50 border-green-200 text-green-800',
+            )}
+          >
+            <span className="flex-1">{toast.message}</span>
+            <button
+              onClick={() => dismissDetailToast(toast.id)}
+              className="flex-shrink-0 opacity-70 hover:opacity-100"
+              aria-label="Dismiss"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        ))}
       </div>
-    </div>;
-};
-export default ProgramBuilder;
+    </div>
+  );
+}

--- a/src/pages/Programs.tsx
+++ b/src/pages/Programs.tsx
@@ -1,0 +1,176 @@
+import React, { useState } from 'react';
+import { Plus, LayoutList, Trash2, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useUser } from '@/context/UserContext';
+import { usePrograms } from '@/hooks/usePrograms';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
+import { ProgramCreateDialog } from '@/components/ProgramBuilder/ProgramCreateDialog';
+import { ProgramStatusBadge } from '@/components/ProgramBuilder/ProgramStatusBadge';
+import { ProgramTagList } from '@/components/ProgramBuilder/ProgramTagList';
+import type { ProgramSummary } from '@/types/program';
+
+type ProgramCardProps = {
+  program: ProgramSummary;
+  onDelete: () => void;
+};
+
+function ProgramCard({ program, onDelete }: ProgramCardProps) {
+  function handleDeleteClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    onDelete();
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4 hover:border-gray-300 transition-colors">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="font-semibold text-gray-900 truncate">{program.name}</h3>
+            <ProgramStatusBadge status={program.status} />
+          </div>
+          {program.description && (
+            <p className="text-sm text-gray-600 mt-1 line-clamp-2">{program.description}</p>
+          )}
+          <div className="flex items-center gap-3 mt-2 flex-wrap">
+            <span className="text-xs text-gray-400">
+              {program.exercise_count}{' '}
+              {program.exercise_count === 1 ? 'exercise' : 'exercises'}
+            </span>
+            {program.tags.length > 0 && <ProgramTagList tags={program.tags} size="sm" />}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={handleDeleteClick}
+          className="flex-shrink-0 p-1.5 rounded hover:bg-red-50 text-gray-400 hover:text-red-500 transition-colors"
+          aria-label="Delete program"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type ClientGroup = {
+  clientId: string;
+  clientName: string;
+  programs: ProgramSummary[];
+};
+
+function groupByClient(programs: ProgramSummary[]): ClientGroup[] {
+  const map: Record<string, ClientGroup> = {};
+  for (const p of programs) {
+    if (!map[p.client_id]) {
+      map[p.client_id] = { clientId: p.client_id, clientName: p.client_name, programs: [] };
+    }
+    map[p.client_id].programs.push(p);
+  }
+  return Object.values(map).sort((a, b) => a.clientName.localeCompare(b.clientName));
+}
+
+export default function ProgramsPage() {
+  const { userId } = useUser();
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const { programs, isLoading, createProgram, deleteProgram, toasts, dismissToast } =
+    usePrograms();
+
+  if (!userId) return null;
+
+  const clientGroups = groupByClient(programs);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-800">Programs</h1>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {programs.length > 0
+              ? `${programs.length} program${programs.length === 1 ? '' : 's'} across your clients`
+              : 'Manage training programs for your clients'}
+          </p>
+        </div>
+        {programs.length > 0 && (
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="h-4 w-4 mr-2" />
+            New Program
+          </Button>
+        )}
+      </div>
+
+      {/* Content */}
+      {isLoading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-24 w-full rounded-lg" />
+          <Skeleton className="h-24 w-full rounded-lg" />
+          <Skeleton className="h-24 w-full rounded-lg" />
+        </div>
+      ) : clientGroups.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-200 py-20 text-center">
+          <LayoutList className="h-10 w-10 text-gray-300 mb-3" />
+          <h2 className="text-base font-semibold text-gray-700 mb-1">No programs yet</h2>
+          <p className="text-sm text-gray-500 max-w-xs mb-5">
+            Create training programs for your clients and track their progress.
+          </p>
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="h-4 w-4 mr-2" />
+            New Program
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-8">
+          {clientGroups.map((group) => (
+            <div key={group.clientId}>
+              <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">
+                {group.clientName}
+              </h2>
+              <div className="space-y-3">
+                {group.programs.map((program) => (
+                  <ProgramCard
+                    key={program.id}
+                    program={program}
+                    onDelete={() => deleteProgram(program.id)}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <ProgramCreateDialog
+        userId={userId}
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreate={createProgram}
+      />
+
+      {/* Toast notifications */}
+      <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={cn(
+              'pointer-events-auto flex items-start gap-3 rounded-lg border px-4 py-3 shadow-lg text-sm max-w-sm',
+              toast.type === 'error'
+                ? 'bg-red-50 border-red-200 text-red-800'
+                : 'bg-green-50 border-green-200 text-green-800',
+            )}
+          >
+            <span className="flex-1">{toast.message}</span>
+            <button
+              onClick={() => dismissToast(toast.id)}
+              className="flex-shrink-0 opacity-70 hover:opacity-100"
+              aria-label="Dismiss"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});

--- a/src/types/program.ts
+++ b/src/types/program.ts
@@ -1,0 +1,75 @@
+export type ProgramStatus = 'DRAFT' | 'READY' | 'IN_PROGRESS' | 'COMPLETE';
+
+export type ProgramExercise = {
+  id: string;
+  exercise_id: string;
+  exercise_name: string;
+  exercise_demo: string | null;
+  tags: string[];
+  order_index: number;
+  sets: number | null;
+  reps: string | null;
+  duration_seconds: number | null;
+  notes: string | null;
+};
+
+export type ProgramSummary = {
+  id: string;
+  name: string;
+  description: string | null;
+  status: ProgramStatus;
+  tags: string[];
+  client_id: string;
+  client_name: string;
+  exercise_count: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Program = {
+  id: string;
+  name: string;
+  description: string | null;
+  status: ProgramStatus;
+  tags: string[];
+  client_id: string;
+  client_name: string;
+  notes: string | null;
+  exercises: ProgramExercise[];
+  created_at: string;
+  updated_at: string;
+};
+
+export type ReorderExercisesDto = {
+  exercises: { id: string; order_index: number }[];
+};
+
+export type CreateProgramDto = {
+  client_id: string;
+  name: string;
+  description?: string;
+  tags?: string[];
+};
+
+export type UpdateProgramDto = {
+  name?: string;
+  description?: string;
+  status?: ProgramStatus;
+  tags?: string[];
+  notes?: string;
+};
+
+export type AddExerciseDto = {
+  exercise_id: string;
+  sets?: number;
+  reps?: string;
+  duration_seconds?: number;
+  notes?: string;
+};
+
+export type UpdateProgramExerciseDto = {
+  sets?: number;
+  reps?: string;
+  duration_seconds?: number;
+  notes?: string;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -222,6 +222,37 @@
   resolved "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz"
   integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
 
+"@dnd-kit/accessibility@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz"
+  integrity sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.3.0", "@dnd-kit/core@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz"
+  integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.1.1"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz"
+  integrity sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz"
+  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@esbuild/darwin-arm64@0.21.5":
   version "0.21.5"
   resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz"


### PR DESCRIPTION
## Summary

- **Programs list page**: shows all trainer programs grouped by client, with status badges, exercise count, tags, and delete. Includes a prominent empty state with a "New Program" button when there are no programs.
- **Program CRUD**: create/delete programs via `usePrograms` hook; create dialog lets you select a client, set name, description, and tags.
- **Program detail editor**: `useProgramDetail` hook + `ProgramBuilderHeader`, `ProgramExerciseList`, `AddExerciseSheet` components support viewing, editing, reordering exercises (drag-and-drop via `@dnd-kit`), and PDF export.
- **Bug fix**: `ProgramCreateDialog` was crashing because it expected `client.user.first_name` but the API returns `client.client_name` — fixed the client type to match the actual response shape.

## Test plan

- [ ] Navigate to Programs tab — list view renders (or empty state if no programs)
- [ ] Click "New Program" — dialog opens with client dropdown populated
- [ ] Create a program — appears in the list grouped under the correct client
- [ ] Delete a program — removed from list with success toast
- [ ] Confirm no console errors on page load or any of the above actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)