### PR TITLE
fix: wire Program Builder and fix client_id for program creation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate, Outlet } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate, Outlet, useLocation } from 'react-router-dom';
 import Sidebar from './components/Layout/Sidebar';
 import Header from './components/Layout/Header';
 import Dashboard from './pages/Dashboard';
 import Calendar from './pages/Calendar';
 import ProgramsPage from './pages/Programs';
+import ProgramBuilderPage from './pages/ProgramBuilder';
 import ClientAnalytics from './pages/ClientAnalytics';
 import Clients from './pages/Clients';
 import Settings from './pages/Settings';
@@ -19,8 +20,11 @@ function UserSelectionGuard() {
   return <UserSelection />;
 }
 
+const FULL_HEIGHT_ROUTES = new Set(['/program-builder']);
+
 function ProtectedLayout() {
   const { userId, isInitializing } = useUser();
+  const { pathname } = useLocation();
   const [sidebarOpen, setSidebarOpen] = useState(true);
 
   if (isInitializing) return null;
@@ -29,12 +33,14 @@ function ProtectedLayout() {
     return <Navigate to="/" replace />;
   }
 
+  const isFullHeight = FULL_HEIGHT_ROUTES.has(pathname);
+
   return (
     <div className="flex h-screen bg-gray-100">
       <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
       <div className="flex-1 flex flex-col overflow-hidden">
         <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
-        <main className="flex-1 overflow-y-auto bg-gray-50 p-4">
+        <main className={isFullHeight ? 'flex-1 overflow-hidden bg-gray-50' : 'flex-1 overflow-y-auto bg-gray-50 p-4'}>
           <Outlet />
         </main>
       </div>
@@ -52,6 +58,7 @@ export function App() {
             <Route path="/dashboard" element={<Dashboard />} />
             <Route path="/calendar" element={<Calendar />} />
             <Route path="/programs" element={<ProgramsPage />} />
+            <Route path="/program-builder" element={<ProgramBuilderPage />} />
             <Route path="/client-analytics" element={<ClientAnalytics />} />
             <Route path="/clients" element={<Clients />} />
             <Route path="/settings" element={<Settings />} />

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { Home, Calendar, Users, Dumbbell, LayoutList, ChevronLeft, ChevronRight, LogOut } from 'lucide-react';
+import { Home, Calendar, Users, Dumbbell, LayoutList, Wrench, ChevronLeft, ChevronRight, LogOut } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useUser } from '@/context/UserContext';
 
@@ -53,6 +53,12 @@ const Sidebar = ({ sidebarOpen, setSidebarOpen }: SidebarProps) => {
       name: 'Programs',
       icon: <LayoutList size={20} />,
       path: '/programs',
+      notifications: 0,
+    },
+    {
+      name: 'Program Builder',
+      icon: <Wrench size={20} />,
+      path: '/program-builder',
       notifications: 0,
     },
     // {

--- a/src/components/ProgramBuilder/ProgramCreateDialog.tsx
+++ b/src/components/ProgramBuilder/ProgramCreateDialog.tsx
@@ -22,7 +22,7 @@ import { TagInput } from './TagInput';
 import type { CreateProgramDto, Program } from '@/types/program';
 
 type Client = {
-  client_id: string;
+  id: string;
   client_name: string;
 };
 
@@ -112,7 +112,7 @@ export function ProgramCreateDialog({
               </SelectTrigger>
               <SelectContent>
                 {clients.map((client) => (
-                  <SelectItem key={client.client_id} value={client.client_id}>
+                  <SelectItem key={client.id} value={client.id}>
                     {client.client_name}
                   </SelectItem>
                 ))}


### PR DESCRIPTION
## Summary

- **Wrong client ID field on program creation**: `ProgramCreateDialog` was reading `client.client_id` (used internally for sessions/notes) instead of `client.id` (the primary key) when populating the client select. This sent an unrecognized UUID to the backend, producing `WARN [ProgramService] Client not found or does not belong to trainer` and failing silently.
- **Program Builder page was unreachable**: `ProgramBuilder.tsx` was fully implemented in the previous PR but never added to the router or sidebar, so editing programs and adding exercises from the library were inaccessible.
- **Layout fix for builder**: `/program-builder` gets a full-height, padding-free layout via a `FULL_HEIGHT_ROUTES` set in `ProtectedLayout`, so the two-panel builder fills the viewport correctly.

## Test plan

- [ ] Navigate to **Program Builder** in the sidebar — confirms the route is now reachable
- [ ] Create a new program — no backend warning, program appears in the sidebar list and auto-selects in the detail panel
- [ ] Click **Edit** on the draft program — edit form opens, changes save successfully
- [ ] Click **Add Exercise** in edit mode — exercise library sheet opens, exercises load, confirm add works
- [ ] Verify the existing `/programs` overview page is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)